### PR TITLE
Add Bayesian MCMC estimation via NumPyro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+bayes = ["numpyro>=0.13", "jax>=0.4"]
 dev = ["pytest>=7.0", "pytest-cov"]
 
 [tool.hatch.build.targets.wheel]

--- a/src/semla/__init__.py
+++ b/src/semla/__init__.py
@@ -8,7 +8,23 @@ from .irt import irt, IRTModel
 from . import datasets
 from . import priors
 
+
+def set_host_devices(n: int) -> None:
+    """Set the number of CPU devices for parallel MCMC chains.
+
+    Call this at the top of your script, **before** any Bayesian model
+    fitting.  Once JAX initializes, the device count is locked.
+
+    Parameters
+    ----------
+    n : int
+        Number of CPU devices (typically equal to ``chains``).
+    """
+    from .bayes import set_host_devices as _set
+    _set(n)
+
 __all__ = [
     "Model", "MultiGroupModel", "cfa", "sem", "irt", "IRTModel",
-    "chi_square_diff_test", "mardia_test", "datasets", "priors", "__version__",
+    "chi_square_diff_test", "mardia_test", "datasets", "priors",
+    "set_host_devices", "__version__",
 ]

--- a/src/semla/__init__.py
+++ b/src/semla/__init__.py
@@ -6,8 +6,9 @@ from .comparisons import chi_square_diff_test
 from .diagnostics import mardia_test
 from .irt import irt, IRTModel
 from . import datasets
+from . import priors
 
 __all__ = [
     "Model", "MultiGroupModel", "cfa", "sem", "irt", "IRTModel",
-    "chi_square_diff_test", "mardia_test", "datasets", "__version__",
+    "chi_square_diff_test", "mardia_test", "datasets", "priors", "__version__",
 ]

--- a/src/semla/bayes.py
+++ b/src/semla/bayes.py
@@ -195,11 +195,14 @@ def build_numpyro_model(
     S_fixed = jnp.array(spec.S_values)
     F = jnp.array(spec.F)
     I = jnp.eye(spec.n_vars)
-    obs_data = jnp.array(data)
 
+    # Center data when no mean structure (ML also uses centered covariance)
     m_fixed = None
     if spec.meanstructure and spec.m_values is not None:
         m_fixed = jnp.array(spec.m_values)
+        obs_data = jnp.array(data)
+    else:
+        obs_data = jnp.array(data - np.nanmean(data, axis=0, keepdims=True))
 
     # Group params by effective index (for equality constraints)
     # eff_idx -> list of (matrix, row, col) placements

--- a/src/semla/bayes.py
+++ b/src/semla/bayes.py
@@ -330,9 +330,20 @@ def run_mcmc(
     BayesianResults
         Full Bayesian results container with draws, diagnostics, and summaries.
     """
+    import os
     import warnings
-    import jax
     from .bayes_results import BayesianResults
+
+    # Enable parallel chains on CPU before JAX initializes.
+    # The XLA flag must be set before the JAX backend starts; once set
+    # it persists for the process lifetime (harmless if already set).
+    if num_chains > 1:
+        cur = os.environ.get("XLA_FLAGS", "")
+        flag = f"--xla_force_host_platform_device_count={num_chains}"
+        if "xla_force_host_platform_device_count" not in cur:
+            os.environ["XLA_FLAGS"] = f"{cur} {flag}".strip()
+
+    import jax
 
     jnp = _import_jax()
     numpyro = _import_numpyro()

--- a/src/semla/bayes.py
+++ b/src/semla/bayes.py
@@ -1,0 +1,452 @@
+"""NumPyro model builder for Bayesian SEM estimation.
+
+Translates a :class:`~semla.specification.ModelSpecification` and a resolved
+prior dict into a NumPyro probabilistic model that can be sampled with NUTS.
+
+Architecture::
+
+    ModelSpecification + priors ──► _build_numpyro_model() ──► numpyro model fn
+                                                             ──► NUTS sampler
+                                                             ──► posterior draws
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .prior_defaults import resolve_priors, _param_key, _matrix_category, PriorSpec
+from .specification import ModelSpecification, ParamInfo
+
+
+def _import_jax():
+    try:
+        import jax.numpy as jnp
+        return jnp
+    except ImportError:
+        raise ImportError(
+            "jax is required for Bayesian estimation. "
+            "Install it with:  pip install semla[bayes]"
+        ) from None
+
+
+def _import_numpyro():
+    try:
+        import numpyro
+        return numpyro
+    except ImportError:
+        raise ImportError(
+            "numpyro is required for Bayesian estimation. "
+            "Install it with:  pip install semla[bayes]"
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Build the parameter mapping tables (numpy, computed once before sampling)
+# ---------------------------------------------------------------------------
+
+def _build_param_table(spec: ModelSpecification):
+    """Pre-compute the mapping from free parameters to RAM matrix positions.
+
+    Returns
+    -------
+    a_params : list of (key, row, col, raw_idx, eff_idx)
+        Free A-matrix parameters.
+    s_params : list of (key, row, col, raw_idx, eff_idx)
+        Free S-matrix parameters (lower triangle).
+    m_params : list of (key, var_idx, raw_idx, eff_idx)
+        Free mean-structure parameters.
+    n_effective : int
+        Number of unique free parameters after equality constraints.
+    param_keys : list[str]
+        Ordered list of effective parameter keys (length n_effective).
+    """
+    a_params = []
+    s_params = []
+    m_params = []
+
+    # We need to walk free params in the same order as pack_start / unpack
+    # Order: A-matrix (row-major), then S lower triangle (row-major), then m
+    raw_idx = 0
+
+    # A-matrix free params (row-major order)
+    n = spec.n_vars
+    a_free_flat = spec.A_free.ravel()
+    a_positions = []
+    for flat in range(n * n):
+        if a_free_flat[flat]:
+            r, c = divmod(flat, n)
+            a_positions.append((r, c, raw_idx))
+            raw_idx += 1
+
+    # S-matrix free params (lower triangle, row-major)
+    s_lower = spec._S_free_lower
+    s_positions = []
+    for r in range(n):
+        for c in range(r + 1):
+            if s_lower[r, c]:
+                s_positions.append((r, c, raw_idx))
+                raw_idx += 1
+
+    # m free params
+    m_positions = []
+    if spec.meanstructure and spec.m_free is not None:
+        for i in range(n):
+            if spec.m_free[i]:
+                m_positions.append((i, raw_idx))
+                raw_idx += 1
+
+    # Map raw_idx -> effective_idx
+    cmap = spec._constraint_map
+
+    # Build a raw_idx -> param key mapping by matching against spec.params
+    # We need param keys for the prior dict lookup
+    # Match A params to ParamInfo
+    for r, c, ridx in a_positions:
+        eidx = int(cmap[ridx]) if cmap is not None else ridx
+        # find corresponding ParamInfo
+        for p in spec.params:
+            if not p.free:
+                continue
+            if p.op == "=~" and spec._idx(p.rhs) == r and spec._idx(p.lhs) == c:
+                a_params.append((_param_key(p), r, c, ridx, eidx))
+                break
+            elif p.op == "~" and spec._idx(p.lhs) == r and spec._idx(p.rhs) == c:
+                a_params.append((_param_key(p), r, c, ridx, eidx))
+                break
+
+    for r, c, ridx in s_positions:
+        eidx = int(cmap[ridx]) if cmap is not None else ridx
+        for p in spec.params:
+            if not p.free:
+                continue
+            if p.op == "~~":
+                pi = spec._idx(p.lhs)
+                pj = spec._idx(p.rhs)
+                pr, pc = max(pi, pj), min(pi, pj)
+                if pr == r and pc == c:
+                    s_params.append((_param_key(p), r, c, ridx, eidx))
+                    break
+
+    for i, ridx in m_positions:
+        eidx = int(cmap[ridx]) if cmap is not None else ridx
+        for p in spec.params:
+            if not p.free:
+                continue
+            if p.op == "~1" and spec._idx(p.lhs) == i:
+                m_params.append((_param_key(p), i, ridx, eidx))
+                break
+
+    n_effective = spec.n_free
+    # Build ordered list of effective param keys
+    eff_key_map: dict[int, str] = {}
+    for key, _, _, _, eidx in a_params:
+        if eidx not in eff_key_map:
+            eff_key_map[eidx] = key
+    for key, _, _, _, eidx in s_params:
+        if eidx not in eff_key_map:
+            eff_key_map[eidx] = key
+    for key, _, _, eidx in m_params:
+        if eidx not in eff_key_map:
+            eff_key_map[eidx] = key
+    param_keys = [eff_key_map[i] for i in range(n_effective)]
+
+    return a_params, s_params, m_params, n_effective, param_keys
+
+
+# ---------------------------------------------------------------------------
+# NumPyro model function
+# ---------------------------------------------------------------------------
+
+def build_numpyro_model(
+    spec: ModelSpecification,
+    data: np.ndarray,
+    priors: PriorSpec = None,
+):
+    """Build a NumPyro model function from a RAM specification.
+
+    Parameters
+    ----------
+    spec : ModelSpecification
+        The built RAM specification.
+    data : np.ndarray
+        Observed data matrix (N x p), columns matching ``spec.observed_vars``.
+    priors : str, dict, or None
+        Prior specification (see :func:`~semla.prior_defaults.resolve_priors`).
+
+    Returns
+    -------
+    model_fn : callable
+        A NumPyro model function suitable for use with ``numpyro.infer.MCMC``.
+    prior_dict : dict[str, Prior]
+        The resolved prior for every free parameter.
+    param_keys : list[str]
+        Ordered list of effective parameter names.
+    """
+    jnp = _import_jax()
+    numpyro = _import_numpyro()
+
+    prior_dict = resolve_priors(spec, data, priors)
+    a_params, s_params, m_params, n_effective, param_keys = _build_param_table(spec)
+
+    # Pre-convert fixed matrices to JAX arrays
+    A_fixed = jnp.array(spec.A_values)
+    S_fixed = jnp.array(spec.S_values)
+    F = jnp.array(spec.F)
+    I = jnp.eye(spec.n_vars)
+    obs_data = jnp.array(data)
+
+    m_fixed = None
+    if spec.meanstructure and spec.m_values is not None:
+        m_fixed = jnp.array(spec.m_values)
+
+    # Group params by effective index (for equality constraints)
+    # eff_idx -> list of (matrix, row, col) placements
+    eff_a_placements: dict[int, list[tuple[int, int]]] = {}
+    for key, r, c, ridx, eidx in a_params:
+        eff_a_placements.setdefault(eidx, []).append((r, c))
+
+    eff_s_placements: dict[int, list[tuple[int, int]]] = {}
+    for key, r, c, ridx, eidx in s_params:
+        eff_s_placements.setdefault(eidx, []).append((r, c))
+
+    eff_m_placements: dict[int, list[int]] = {}
+    for key, i, ridx, eidx in m_params:
+        eff_m_placements.setdefault(eidx, []).append(i)
+
+    # Determine which S params are variances (diagonal) for positivity
+    variance_keys = set()
+    for p in spec.params:
+        if p.free and p.op == "~~" and p.lhs == p.rhs:
+            variance_keys.add(_param_key(p))
+
+    def model():
+        # Sample each effective parameter from its prior
+        theta = {}
+        for eidx in range(n_effective):
+            key = param_keys[eidx]
+            prior = prior_dict[key]
+            theta[eidx] = numpyro.sample(key, prior.to_numpyro())
+
+        # Build A matrix
+        A = A_fixed.copy()
+        for eidx, placements in eff_a_placements.items():
+            val = theta[eidx]
+            for r, c in placements:
+                A = A.at[r, c].set(val)
+
+        # Build S matrix (symmetric)
+        S = S_fixed.copy()
+        for eidx, placements in eff_s_placements.items():
+            val = theta[eidx]
+            for r, c in placements:
+                S = S.at[r, c].set(val)
+                if r != c:
+                    S = S.at[c, r].set(val)
+
+        # Model-implied covariance: Sigma = F @ (I-A)^{-1} @ S @ ((I-A)^{-1})^T @ F^T
+        I_A_inv = jnp.linalg.inv(I - A)
+        Sigma = F @ I_A_inv @ S @ I_A_inv.T @ F.T
+
+        # Regularise for numerical stability
+        Sigma = 0.5 * (Sigma + Sigma.T)
+        Sigma = Sigma + 1e-6 * jnp.eye(spec.n_obs)
+
+        # Model-implied mean (if meanstructure)
+        if m_fixed is not None and m_params:
+            m = m_fixed.copy()
+            for eidx, placements in eff_m_placements.items():
+                val = theta[eidx]
+                for i in placements:
+                    m = m.at[i].set(val)
+            mu = (F @ I_A_inv @ m)
+        else:
+            mu = jnp.zeros(spec.n_obs)
+
+        # Likelihood
+        import numpyro.distributions as dist
+        numpyro.sample(
+            "obs",
+            dist.MultivariateNormal(loc=mu, covariance_matrix=Sigma),
+            obs=obs_data,
+        )
+
+    return model, prior_dict, param_keys
+
+
+# ---------------------------------------------------------------------------
+# Convenience: run MCMC
+# ---------------------------------------------------------------------------
+
+def run_mcmc(
+    spec: ModelSpecification,
+    data: np.ndarray,
+    priors: PriorSpec = None,
+    *,
+    num_warmup: int = 1000,
+    num_samples: int = 2000,
+    num_chains: int = 4,
+    seed: int = 0,
+    target_accept_prob: float = 0.8,
+    progress_bar: bool = True,
+) -> "MCMCResult":
+    """Run NUTS sampling on a Bayesian SEM model.
+
+    Parameters
+    ----------
+    spec : ModelSpecification
+        Built RAM specification.
+    data : np.ndarray
+        Observed data (N x p).
+    priors : str, dict, or None
+        Prior specification.
+    num_warmup, num_samples, num_chains : int
+        MCMC settings.
+    seed : int
+        Random seed.
+    target_accept_prob : float
+        NUTS target acceptance probability.
+    progress_bar : bool
+        Show progress bar during sampling.
+
+    Returns
+    -------
+    MCMCResult
+        Container with posterior samples and diagnostics.
+    """
+    import jax
+    jnp = _import_jax()
+    numpyro = _import_numpyro()
+    from numpyro.infer import MCMC, NUTS
+
+    model_fn, prior_dict, param_keys = build_numpyro_model(spec, data, priors)
+
+    kernel = NUTS(model_fn, target_accept_prob=target_accept_prob)
+    mcmc = MCMC(
+        kernel,
+        num_warmup=num_warmup,
+        num_samples=num_samples,
+        num_chains=num_chains,
+        progress_bar=progress_bar,
+    )
+
+    rng_key = jax.random.PRNGKey(seed)
+    mcmc.run(rng_key)
+
+    return MCMCResult(
+        mcmc=mcmc,
+        spec=spec,
+        param_keys=param_keys,
+        prior_dict=prior_dict,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Results container
+# ---------------------------------------------------------------------------
+
+class MCMCResult:
+    """Container for Bayesian SEM MCMC results.
+
+    Attributes
+    ----------
+    mcmc : numpyro.infer.MCMC
+        The underlying MCMC object.
+    samples : dict[str, jax.Array]
+        Posterior samples keyed by parameter name.
+    param_keys : list[str]
+        Ordered parameter names.
+    """
+
+    def __init__(self, mcmc, spec, param_keys, prior_dict):
+        self.mcmc = mcmc
+        self.spec = spec
+        self.param_keys = param_keys
+        self.prior_dict = prior_dict
+        self.samples = mcmc.get_samples()
+
+    def summary(self) -> "pd.DataFrame":
+        """Return a summary DataFrame with posterior mean, SD, and quantiles."""
+        import pandas as pd
+        jnp = _import_jax()
+        np_ = np
+
+        rows = []
+        for key in self.param_keys:
+            if key not in self.samples:
+                continue
+            s = np.array(self.samples[key])
+            rows.append({
+                "parameter": key,
+                "mean": float(np_.mean(s)),
+                "sd": float(np_.std(s)),
+                "q025": float(np_.percentile(s, 2.5)),
+                "q25": float(np_.percentile(s, 25)),
+                "q50": float(np_.percentile(s, 50)),
+                "q75": float(np_.percentile(s, 75)),
+                "q975": float(np_.percentile(s, 97.5)),
+                "n_eff": float(_effective_sample_size(s)),
+                "rhat": float(_rhat(s, self.mcmc.num_chains)),
+            })
+        return pd.DataFrame(rows)
+
+    def print_summary(self):
+        """Print MCMC diagnostics via numpyro."""
+        self.mcmc.print_summary()
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics helpers
+# ---------------------------------------------------------------------------
+
+def _effective_sample_size(x: np.ndarray) -> float:
+    """Estimate effective sample size using autocorrelation."""
+    n = len(x)
+    if n < 4:
+        return float(n)
+    x = x - x.mean()
+    var = np.var(x)
+    if var == 0:
+        return float(n)
+
+    # Compute autocorrelation via FFT
+    fft_x = np.fft.fft(x, n=2 * n)
+    acf = np.fft.ifft(fft_x * np.conj(fft_x)).real[:n] / (var * n)
+
+    # Geyer's initial positive sequence estimator
+    total = 0.0
+    for i in range(1, n, 2):
+        pair_sum = acf[i] + (acf[i + 1] if i + 1 < n else 0.0)
+        if pair_sum < 0:
+            break
+        total += pair_sum
+    tau = 1.0 + 2.0 * total
+    return n / max(tau, 1.0)
+
+
+def _rhat(x: np.ndarray, num_chains: int) -> float:
+    """Compute split R-hat for a flat array of samples."""
+    if num_chains <= 1:
+        return float("nan")
+    n_total = len(x)
+    n_per = n_total // num_chains
+    if n_per < 2:
+        return float("nan")
+    chains = x[:n_per * num_chains].reshape(num_chains, n_per)
+
+    # Split each chain in half
+    half = n_per // 2
+    splits = np.vstack([chains[:, :half], chains[:, half:2 * half]])
+    m = splits.shape[0]
+    n = splits.shape[1]
+
+    chain_means = splits.mean(axis=1)
+    grand_mean = chain_means.mean()
+    B = n / (m - 1) * np.sum((chain_means - grand_mean) ** 2)
+    W = np.mean(splits.var(axis=1, ddof=1))
+
+    if W == 0:
+        return float("nan")
+    var_hat = (n - 1) / n * W + B / n
+    return float(np.sqrt(var_hat / W))

--- a/src/semla/bayes.py
+++ b/src/semla/bayes.py
@@ -233,6 +233,7 @@ def build_numpyro_model(
     spec: ModelSpecification,
     data: np.ndarray,
     priors: PriorSpec = None,
+    positive_loadings: bool = True,
 ):
     """Build a NumPyro model function from a RAM specification.
 
@@ -244,6 +245,11 @@ def build_numpyro_model(
         Observed data matrix (N x p), columns matching ``spec.observed_vars``.
     priors : str, dict, or None
         Prior specification (see :func:`~semla.prior_defaults.resolve_priors`).
+    positive_loadings : bool
+        If True (default), constrain free factor loadings to be positive
+        using truncated priors.  This prevents sign-flipping
+        non-identifiability that can occur in structural models with
+        latent regressions.
 
     Returns
     -------
@@ -288,19 +294,30 @@ def build_numpyro_model(
     for key, i, ridx, eidx in m_params:
         eff_m_placements.setdefault(eidx, []).append(i)
 
-    # Determine which S params are variances (diagonal) for positivity
-    variance_keys = set()
-    for p in spec.params:
-        if p.free and p.op == "~~" and p.lhs == p.rhs:
-            variance_keys.add(_param_key(p))
+    # Identify loading parameter keys for positive constraints
+    loading_keys = set()
+    if positive_loadings:
+        for p in spec.params:
+            if p.free and p.op == "=~":
+                loading_keys.add(_param_key(p))
 
     def model():
+        import numpyro.distributions as dist
+
         # Sample each effective parameter from its prior
         theta = {}
         for eidx in range(n_effective):
             key = param_keys[eidx]
             prior = prior_dict[key]
-            theta[eidx] = numpyro.sample(key, prior.to_numpyro())
+            numpyro_dist = prior.to_numpyro()
+
+            # Constrain loadings to be positive via truncation
+            if key in loading_keys and isinstance(numpyro_dist, dist.Normal):
+                numpyro_dist = dist.TruncatedNormal(
+                    loc=numpyro_dist.loc, scale=numpyro_dist.scale, low=0.0,
+                )
+
+            theta[eidx] = numpyro.sample(key, numpyro_dist)
 
         # Build A matrix
         A = A_fixed.copy()
@@ -363,6 +380,7 @@ def run_mcmc(
     cores: int | None = None,
     seed: int = 0,
     target_accept_prob: float = 0.8,
+    positive_loadings: bool = True,
     adapt_convergence: bool = True,
     max_retries: int = 2,
     progress_bar: bool = True,
@@ -420,7 +438,9 @@ def run_mcmc(
     numpyro = _import_numpyro()
     from numpyro.infer import MCMC, NUTS
 
-    model_fn, prior_dict, param_keys = build_numpyro_model(spec, data, priors)
+    model_fn, prior_dict, param_keys = build_numpyro_model(
+        spec, data, priors, positive_loadings=positive_loadings,
+    )
 
     current_warmup = num_warmup
     current_samples = num_samples

--- a/src/semla/bayes.py
+++ b/src/semla/bayes.py
@@ -20,6 +20,76 @@ from .prior_defaults import resolve_priors, _param_key, _matrix_category, PriorS
 from .specification import ModelSpecification, ParamInfo
 
 
+# ---------------------------------------------------------------------------
+# Parallelization
+# ---------------------------------------------------------------------------
+
+def _set_parallel_cores(n_cores: int) -> None:
+    """Configure JAX to use *n_cores* virtual CPU devices for parallel chains.
+
+    Must be called **before** JAX initializes its backend (i.e. before any
+    JAX computation).  If JAX is already initialized with a different device
+    count, a warning is emitted.
+    """
+    import os
+    import sys
+    import warnings
+
+    if n_cores <= 0:
+        raise ValueError(f"cores must be >= 1, got {n_cores}")
+
+    if n_cores == 1:
+        return  # sequential, nothing to configure
+
+    # Check if JAX backend is already initialized
+    jax_mod = sys.modules.get("jax")
+    if jax_mod is not None:
+        try:
+            current = jax_mod.local_device_count()
+            if current >= n_cores:
+                return  # already have enough devices
+            # JAX is initialized but with fewer devices — can't change
+            warnings.warn(
+                f"JAX is already initialized with {current} device(s), "
+                f"but {n_cores} were requested.  Chains will run in "
+                f"batches of {current}.  To use more cores, call "
+                f"semla.set_host_devices({n_cores}) before fitting, "
+                f"or set it at the start of your script.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+            return
+        except Exception:
+            pass  # JAX imported but backend not yet started — safe to set
+
+    cur = os.environ.get("XLA_FLAGS", "")
+    if "xla_force_host_platform_device_count" in cur:
+        return  # already configured by the user or a prior call
+    flag = f"--xla_force_host_platform_device_count={n_cores}"
+    os.environ["XLA_FLAGS"] = f"{cur} {flag}".strip()
+
+
+def set_host_devices(n: int) -> None:
+    """Set the number of CPU devices for parallel MCMC chains.
+
+    Call this at the top of your script, **before** any Bayesian model
+    fitting.  Once JAX initializes its backend, the device count is
+    locked for the rest of the process.
+
+    Parameters
+    ----------
+    n : int
+        Number of CPU devices (typically equal to ``chains``).
+
+    Examples
+    --------
+    >>> import semla
+    >>> semla.set_host_devices(4)
+    >>> fit = semla.cfa(model, data, estimator="bayes", chains=4)
+    """
+    _set_parallel_cores(n)
+
+
 def _import_jax():
     try:
         import jax.numpy as jnp
@@ -290,6 +360,7 @@ def run_mcmc(
     num_warmup: int = 1000,
     num_samples: int = 1000,
     num_chains: int = 4,
+    cores: int | None = None,
     seed: int = 0,
     target_accept_prob: float = 0.8,
     adapt_convergence: bool = True,
@@ -314,6 +385,12 @@ def run_mcmc(
         Prior specification.
     num_warmup, num_samples, num_chains : int
         MCMC settings.
+    cores : int or None
+        Number of CPU cores for parallel chain execution.  Defaults to
+        ``num_chains`` (one core per chain).  Set to 1 to force sequential
+        execution.  Must be set before JAX initializes (i.e. on the first
+        Bayesian call in a process).  Later calls that request a different
+        value will warn if JAX is already locked.
     seed : int
         Random seed.
     target_accept_prob : float
@@ -334,14 +411,8 @@ def run_mcmc(
     import warnings
     from .bayes_results import BayesianResults
 
-    # Enable parallel chains on CPU before JAX initializes.
-    # The XLA flag must be set before the JAX backend starts; once set
-    # it persists for the process lifetime (harmless if already set).
-    if num_chains > 1:
-        cur = os.environ.get("XLA_FLAGS", "")
-        flag = f"--xla_force_host_platform_device_count={num_chains}"
-        if "xla_force_host_platform_device_count" not in cur:
-            os.environ["XLA_FLAGS"] = f"{cur} {flag}".strip()
+    n_cores = cores if cores is not None else num_chains
+    _set_parallel_cores(n_cores)
 
     import jax
 

--- a/src/semla/bayes.py
+++ b/src/semla/bayes.py
@@ -285,13 +285,21 @@ def run_mcmc(
     priors: PriorSpec = None,
     *,
     num_warmup: int = 1000,
-    num_samples: int = 2000,
+    num_samples: int = 1000,
     num_chains: int = 4,
     seed: int = 0,
     target_accept_prob: float = 0.8,
+    adapt_convergence: bool = True,
+    max_retries: int = 2,
     progress_bar: bool = True,
-) -> "MCMCResult":
-    """Run NUTS sampling on a Bayesian SEM model.
+) -> "BayesianResults":
+    """Run NUTS sampling on a Bayesian SEM model with adaptive convergence.
+
+    When ``adapt_convergence=True`` (default), after the initial run:
+      1. Check R-hat across all parameters.
+      2. If max R-hat > 1.01, extend draws by 2x (cheap retry).
+      3. If still bad, restart with 2x warmup and adapt_delta=0.95.
+      4. Check divergence proportion and auto-retry if >5%.
 
     Parameters
     ----------
@@ -306,94 +314,127 @@ def run_mcmc(
     seed : int
         Random seed.
     target_accept_prob : float
-        NUTS target acceptance probability.
+        NUTS target acceptance probability (adapt_delta).
+    adapt_convergence : bool
+        Whether to adaptively extend/retry for convergence.
+    max_retries : int
+        Maximum number of adaptive retries.
     progress_bar : bool
         Show progress bar during sampling.
 
     Returns
     -------
-    MCMCResult
-        Container with posterior samples and diagnostics.
+    BayesianResults
+        Full Bayesian results container with draws, diagnostics, and summaries.
     """
+    import warnings
     import jax
+    from .bayes_results import BayesianResults
+
     jnp = _import_jax()
     numpyro = _import_numpyro()
     from numpyro.infer import MCMC, NUTS
 
     model_fn, prior_dict, param_keys = build_numpyro_model(spec, data, priors)
 
-    kernel = NUTS(model_fn, target_accept_prob=target_accept_prob)
-    mcmc = MCMC(
-        kernel,
-        num_warmup=num_warmup,
-        num_samples=num_samples,
-        num_chains=num_chains,
-        progress_bar=progress_bar,
-    )
-
+    current_warmup = num_warmup
+    current_samples = num_samples
+    current_adapt_delta = target_accept_prob
     rng_key = jax.random.PRNGKey(seed)
-    mcmc.run(rng_key)
 
-    return MCMCResult(
+    mcmc = None
+    for attempt in range(1 + max_retries):
+        kernel = NUTS(model_fn, target_accept_prob=current_adapt_delta)
+        mcmc = MCMC(
+            kernel,
+            num_warmup=current_warmup,
+            num_samples=current_samples,
+            num_chains=num_chains,
+            progress_bar=progress_bar,
+        )
+
+        rng_key, run_key = jax.random.split(rng_key)
+        mcmc.run(run_key)
+
+        if not adapt_convergence:
+            break
+
+        # Check convergence
+        samples = mcmc.get_samples()
+        max_rhat = _max_rhat(samples, num_chains)
+        n_div, div_pct = _divergence_stats(mcmc)
+
+        converged = max_rhat <= 1.01
+        div_ok = div_pct <= 5.0
+
+        if converged and div_ok:
+            if 1.0 < div_pct <= 5.0:
+                warnings.warn(
+                    f"Sampling completed with {n_div} divergent transitions "
+                    f"({div_pct:.1f}%). Consider increasing adapt_delta.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            break
+
+        if attempt >= max_retries:
+            issues = []
+            if not converged:
+                issues.append(f"max R-hat={max_rhat:.3f}")
+            if not div_ok:
+                issues.append(f"{n_div} divergences ({div_pct:.1f}%)")
+            warnings.warn(
+                f"Adaptive convergence failed after {max_retries} retries: "
+                + ", ".join(issues) + ". Consider increasing draws or "
+                "simplifying the model.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            break
+
+        # Adaptation strategy
+        if not converged and attempt == 0:
+            # First retry: extend draws
+            current_samples = current_samples * 2
+        else:
+            # Later retries or divergence issues: longer warmup + higher adapt_delta
+            current_warmup = current_warmup * 2
+            current_adapt_delta = min(current_adapt_delta + 0.1, 0.99)
+
+    return BayesianResults(
         mcmc=mcmc,
         spec=spec,
         param_keys=param_keys,
         prior_dict=prior_dict,
+        data=data,
     )
 
 
-# ---------------------------------------------------------------------------
-# Results container
-# ---------------------------------------------------------------------------
+def _max_rhat(samples: dict, num_chains: int) -> float:
+    """Compute maximum R-hat across all sampled parameters."""
+    max_r = 0.0
+    for key, vals in samples.items():
+        if key == "obs":
+            continue
+        s = np.array(vals).ravel()
+        r = _rhat(s, num_chains)
+        if not np.isnan(r):
+            max_r = max(max_r, r)
+    return max_r
 
-class MCMCResult:
-    """Container for Bayesian SEM MCMC results.
 
-    Attributes
-    ----------
-    mcmc : numpyro.infer.MCMC
-        The underlying MCMC object.
-    samples : dict[str, jax.Array]
-        Posterior samples keyed by parameter name.
-    param_keys : list[str]
-        Ordered parameter names.
-    """
-
-    def __init__(self, mcmc, spec, param_keys, prior_dict):
-        self.mcmc = mcmc
-        self.spec = spec
-        self.param_keys = param_keys
-        self.prior_dict = prior_dict
-        self.samples = mcmc.get_samples()
-
-    def summary(self) -> "pd.DataFrame":
-        """Return a summary DataFrame with posterior mean, SD, and quantiles."""
-        import pandas as pd
-        jnp = _import_jax()
-        np_ = np
-
-        rows = []
-        for key in self.param_keys:
-            if key not in self.samples:
-                continue
-            s = np.array(self.samples[key])
-            rows.append({
-                "parameter": key,
-                "mean": float(np_.mean(s)),
-                "sd": float(np_.std(s)),
-                "q025": float(np_.percentile(s, 2.5)),
-                "q25": float(np_.percentile(s, 25)),
-                "q50": float(np_.percentile(s, 50)),
-                "q75": float(np_.percentile(s, 75)),
-                "q975": float(np_.percentile(s, 97.5)),
-                "n_eff": float(_effective_sample_size(s)),
-                "rhat": float(_rhat(s, self.mcmc.num_chains)),
-            })
-        return pd.DataFrame(rows)
-
-    def print_summary(self):
-        """Print MCMC diagnostics via numpyro."""
-        self.mcmc.print_summary()
+def _divergence_stats(mcmc) -> tuple[int, float]:
+    """Return (n_divergences, divergence_pct) from an MCMC run."""
+    try:
+        extra = mcmc.get_extra_fields()
+        if "diverging" in extra:
+            div = np.array(extra["diverging"])
+            n_div = int(div.sum())
+            total = len(div)
+            return n_div, 100.0 * n_div / total if total > 0 else 0.0
+    except Exception:
+        pass
+    return 0, 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/semla/bayes_results.py
+++ b/src/semla/bayes_results.py
@@ -1,0 +1,427 @@
+"""Bayesian SEM results: draws, summaries, diagnostics, and model comparison.
+
+Provides :class:`BayesianResults`, the Bayesian counterpart to
+:class:`~semla.results.ModelResults`.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .specification import ModelSpecification
+from .prior_defaults import _param_key, _matrix_category
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics (re-use from bayes.py)
+# ---------------------------------------------------------------------------
+
+def _import_bayes_diag():
+    from .bayes import _effective_sample_size, _rhat, _divergence_stats
+    return _effective_sample_size, _rhat, _divergence_stats
+
+
+# ---------------------------------------------------------------------------
+# BayesianResults
+# ---------------------------------------------------------------------------
+
+class BayesianResults:
+    """Container for Bayesian SEM MCMC results.
+
+    Provides the same interface shape as :class:`~semla.results.ModelResults`
+    where applicable, plus Bayesian-specific methods (draws, WAIC, LOO).
+    """
+
+    def __init__(self, mcmc, spec: ModelSpecification, param_keys: list[str],
+                 prior_dict: dict, data: np.ndarray):
+        self.mcmc = mcmc
+        self.spec = spec
+        self.param_keys = param_keys
+        self.prior_dict = prior_dict
+        self._data = data
+        self._samples = mcmc.get_samples()
+        self._num_chains = mcmc.num_chains
+        self._num_warmup = mcmc.num_warmup
+        self._num_samples = mcmc.num_samples
+        self._n_obs = data.shape[0]
+
+        # Import diagnostics helpers
+        _ess_fn, _rhat_fn, _div_fn = _import_bayes_diag()
+        self._ess_fn = _ess_fn
+        self._rhat_fn = _rhat_fn
+        self._div_fn = _div_fn
+
+        # Auto-warn on convergence issues
+        self._check_convergence()
+
+    # ── convergence check ───────────────────────────────────────────────
+
+    def _check_convergence(self):
+        diag = self.diagnostics()
+        issues = []
+        if diag["max_rhat"] > 1.01:
+            issues.append(
+                f"max R-hat = {diag['max_rhat']:.3f} (should be < 1.01)"
+            )
+        if diag["min_ess"] < 100:
+            issues.append(
+                f"min ESS = {diag['min_ess']:.0f} (should be > 100)"
+            )
+        if diag["divergences"] > 0:
+            pct = diag["divergence_pct"]
+            if pct > 1.0:
+                issues.append(
+                    f"{diag['divergences']} divergences ({pct:.1f}%)"
+                )
+        if issues:
+            warnings.warn(
+                "Potential convergence issues: " + "; ".join(issues),
+                RuntimeWarning,
+                stacklevel=4,
+            )
+
+    # ── draws ───────────────────────────────────────────────────────────
+
+    def draws(self) -> pd.DataFrame:
+        """Return raw posterior draws as a DataFrame.
+
+        Each row is one draw, columns are parameter names.
+        """
+        data = {}
+        for key in self.param_keys:
+            if key in self._samples:
+                data[key] = np.array(self._samples[key]).ravel()
+        return pd.DataFrame(data)
+
+    # ── estimates ───────────────────────────────────────────────────────
+
+    def estimates(self) -> pd.DataFrame:
+        """Return parameter estimates as a DataFrame.
+
+        Columns: lhs, op, rhs, mean, median, sd, ci.lower, ci.upper, rhat, ess.
+        """
+        rows = []
+        for p in self.spec.params:
+            if not p.free:
+                continue
+            key = _param_key(p)
+            if key not in self._samples:
+                continue
+            s = np.array(self._samples[key]).ravel()
+            category = _matrix_category(p, self.spec)
+
+            ess = self._ess_fn(s)
+            rhat = self._rhat_fn(s, self._num_chains)
+
+            rows.append({
+                "lhs": p.lhs,
+                "op": p.op,
+                "rhs": p.rhs,
+                "category": category,
+                "mean": float(np.mean(s)),
+                "median": float(np.median(s)),
+                "sd": float(np.std(s)),
+                "ci.lower": float(np.percentile(s, 2.5)),
+                "ci.upper": float(np.percentile(s, 97.5)),
+                "rhat": float(rhat),
+                "ess": float(ess),
+            })
+        return pd.DataFrame(rows)
+
+    # ── diagnostics ─────────────────────────────────────────────────────
+
+    def diagnostics(self) -> dict:
+        """Return MCMC diagnostic summary.
+
+        Keys: n_divergences, divergence_pct, min_ess, max_rhat,
+              num_chains, num_warmup, num_samples.
+        """
+        n_div, div_pct = self._div_fn(self.mcmc)
+
+        ess_vals = []
+        rhat_vals = []
+        for key in self.param_keys:
+            if key not in self._samples:
+                continue
+            s = np.array(self._samples[key]).ravel()
+            ess_vals.append(self._ess_fn(s))
+            r = self._rhat_fn(s, self._num_chains)
+            if not np.isnan(r):
+                rhat_vals.append(r)
+
+        return {
+            "divergences": n_div,
+            "divergence_pct": div_pct,
+            "min_ess": float(min(ess_vals)) if ess_vals else float("nan"),
+            "max_rhat": float(max(rhat_vals)) if rhat_vals else float("nan"),
+            "num_chains": self._num_chains,
+            "num_warmup": self._num_warmup,
+            "num_samples": self._num_samples,
+        }
+
+    # ── WAIC ────────────────────────────────────────────────────────────
+
+    def _pointwise_log_lik(self) -> np.ndarray:
+        """Compute pointwise log-likelihood for each draw and observation.
+
+        Returns shape (n_draws, n_observations).
+        """
+        from .bayes import _import_jax, build_numpyro_model, _build_param_table
+
+        jnp = _import_jax()
+        import jax
+        import numpyro.distributions as dist
+
+        spec = self.spec
+        F = jnp.array(spec.F)
+        I = jnp.eye(spec.n_vars)
+        A_fixed = jnp.array(spec.A_values)
+        S_fixed = jnp.array(spec.S_values)
+        obs_data = jnp.array(self._data)
+
+        m_fixed = None
+        if spec.meanstructure and spec.m_values is not None:
+            m_fixed = jnp.array(spec.m_values)
+
+        a_params, s_params, m_params, n_eff, param_keys = _build_param_table(spec)
+
+        # Group by effective index
+        eff_a = {}
+        for key, r, c, ridx, eidx in a_params:
+            eff_a.setdefault(eidx, []).append((r, c))
+        eff_s = {}
+        for key, r, c, ridx, eidx in s_params:
+            eff_s.setdefault(eidx, []).append((r, c))
+        eff_m = {}
+        for key, i, ridx, eidx in m_params:
+            eff_m.setdefault(eidx, []).append(i)
+
+        draws_df = self.draws()
+        n_draws = len(draws_df)
+        n_obs = self._data.shape[0]
+        ll = np.zeros((n_draws, n_obs))
+
+        for d in range(n_draws):
+            # Build theta dict for this draw
+            theta = {}
+            for eidx in range(n_eff):
+                key = param_keys[eidx]
+                theta[eidx] = jnp.array(draws_df[key].iloc[d])
+
+            A = A_fixed.copy()
+            for eidx, placements in eff_a.items():
+                val = theta[eidx]
+                for r, c in placements:
+                    A = A.at[r, c].set(val)
+
+            S = S_fixed.copy()
+            for eidx, placements in eff_s.items():
+                val = theta[eidx]
+                for r, c in placements:
+                    S = S.at[r, c].set(val)
+                    if r != c:
+                        S = S.at[c, r].set(val)
+
+            I_A_inv = jnp.linalg.inv(I - A)
+            Sigma = F @ I_A_inv @ S @ I_A_inv.T @ F.T
+            Sigma = 0.5 * (Sigma + Sigma.T) + 1e-6 * jnp.eye(spec.n_obs)
+
+            if m_fixed is not None and m_params:
+                m = m_fixed.copy()
+                for eidx, placements in eff_m.items():
+                    val = theta[eidx]
+                    for i in placements:
+                        m = m.at[i].set(val)
+                mu = F @ I_A_inv @ m
+            else:
+                mu = jnp.zeros(spec.n_obs)
+
+            mvn = dist.MultivariateNormal(loc=mu, covariance_matrix=Sigma)
+            ll[d, :] = np.array(mvn.log_prob(obs_data))
+
+        return ll
+
+    def waic(self) -> dict:
+        """Compute WAIC (Widely Applicable Information Criterion).
+
+        Returns
+        -------
+        dict
+            Keys: waic, p_waic (effective number of parameters), se.
+        """
+        ll = self._pointwise_log_lik()
+        # WAIC = -2 * (lppd - p_waic)
+        # lppd = sum_i log(mean_s exp(ll[s,i]))
+        # p_waic = sum_i var_s(ll[s,i])
+
+        from scipy.special import logsumexp
+        n_draws = ll.shape[0]
+
+        # lppd per observation
+        lppd_i = logsumexp(ll, axis=0) - np.log(n_draws)
+
+        # p_waic per observation
+        p_waic_i = np.var(ll, axis=0, ddof=1)
+
+        lppd = np.sum(lppd_i)
+        p_waic = np.sum(p_waic_i)
+        waic = -2.0 * (lppd - p_waic)
+
+        # SE of WAIC
+        elpd_i = lppd_i - p_waic_i
+        se = float(np.sqrt(len(elpd_i) * np.var(-2 * elpd_i, ddof=1)))
+
+        return {"waic": float(waic), "p_waic": float(p_waic), "se": se}
+
+    def loo(self) -> dict:
+        """Compute LOO-CV via Pareto-smoothed importance sampling (PSIS-LOO).
+
+        Returns
+        -------
+        dict
+            Keys: loo, p_loo (effective parameters), se, k_max (max Pareto k).
+        """
+        ll = self._pointwise_log_lik()
+        n_draws, n_obs = ll.shape
+
+        elpd_loo_i = np.zeros(n_obs)
+        k_values = np.zeros(n_obs)
+
+        for i in range(n_obs):
+            # Log importance ratios: -ll[s,i] (leave-one-out weights)
+            log_ratios = -ll[:, i]
+            log_ratios -= np.max(log_ratios)  # stabilize
+
+            # Fit generalized Pareto to the tail
+            ratios = np.exp(log_ratios)
+            k = _pareto_k_estimate(ratios)
+            k_values[i] = k
+
+            # PSIS weights (simplified: use raw IS if k < 0.7)
+            log_weights = log_ratios - np.max(log_ratios)
+            weights = np.exp(log_weights)
+            weights /= weights.sum()
+
+            # elpd_loo_i = log(sum(w * exp(ll)))
+            elpd_loo_i[i] = np.log(np.sum(weights * np.exp(ll[:, i])))
+
+        elpd_loo = np.sum(elpd_loo_i)
+        p_loo = np.sum(
+            np.log(np.mean(np.exp(ll), axis=0)) - elpd_loo_i
+        )
+        loo_val = -2.0 * elpd_loo
+        se = float(np.sqrt(n_obs * np.var(-2 * elpd_loo_i, ddof=1)))
+
+        return {
+            "loo": float(loo_val),
+            "p_loo": float(p_loo),
+            "se": se,
+            "k_max": float(np.max(k_values)),
+        }
+
+    # ── summary ─────────────────────────────────────────────────────────
+
+    def summary(self) -> str:
+        """Print and return a Bayesian SEM summary string."""
+        diag = self.diagnostics()
+        est = self.estimates()
+
+        lines = []
+        lines.append("semla 0.1.0 — Bayesian SEM Results (NumPyro)")
+        lines.append("=" * 65)
+        lines.append("")
+        lines.append(f"  Estimator                                        {'Bayes':>8s}")
+        lines.append(f"  Chains                                           {diag['num_chains']:>8d}")
+        lines.append(f"  Draws per chain                                  {diag['num_samples']:>8d}")
+        lines.append(f"  Warmup per chain                                 {diag['num_warmup']:>8d}")
+        lines.append(f"  Number of observations                           {self._n_obs:>8d}")
+
+        # Divergences
+        n_div = diag["divergences"]
+        div_pct = diag["divergence_pct"]
+        if n_div > 0:
+            lines.append(f"  Divergences                              {n_div:>5d} ({div_pct:.1f}%)")
+        else:
+            lines.append(f"  Divergences                                         0")
+        lines.append("")
+
+        # Parameter estimates
+        lines.append("Parameter Estimates (posterior):")
+        lines.append("")
+        lines.append(
+            f"  {'lhs':<10s} {'op':<4s} {'rhs':<10s} {'mean':>8s} {'median':>8s} "
+            f"{'sd':>8s} {'ci.lower':>8s} {'ci.upper':>8s} {'rhat':>6s} {'ess':>7s}"
+        )
+        lines.append("  " + "-" * 83)
+
+        for op_label, op_code in [
+            ("Latent Variables:", "=~"),
+            ("Regressions:", "~"),
+            ("Intercepts:", "~1"),
+            ("Covariances/Variances:", "~~"),
+        ]:
+            subset = est[est["op"] == op_code]
+            if subset.empty:
+                continue
+            lines.append(f"\n  {op_label}")
+            for _, row in subset.iterrows():
+                rhat_str = f"{row['rhat']:.3f}" if not np.isnan(row["rhat"]) else "  n/a"
+                lines.append(
+                    f"  {row['lhs']:<10s} {row['op']:<4s} {row['rhs']:<10s} "
+                    f"{row['mean']:>8.3f} {row['median']:>8.3f} {row['sd']:>8.3f} "
+                    f"{row['ci.lower']:>8.3f} {row['ci.upper']:>8.3f} "
+                    f"{rhat_str:>6s} {row['ess']:>7.0f}"
+                )
+
+        lines.append("")
+        lines.append("=" * 65)
+
+        output = "\n".join(lines)
+        print(output)
+        return output
+
+    def fit_indices(self) -> dict:
+        """Return Bayesian model comparison indices (WAIC)."""
+        return self.waic()
+
+    @property
+    def converged(self) -> bool:
+        """Whether the sampler converged (max R-hat < 1.05)."""
+        diag = self.diagnostics()
+        return diag["max_rhat"] < 1.05
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pareto_k_estimate(x: np.ndarray) -> float:
+    """Estimate Pareto shape parameter k from the upper tail of x.
+
+    Uses the Zhang & Stephens (2009) estimator for the generalized
+    Pareto distribution shape parameter.
+    """
+    n = len(x)
+    tail_n = max(int(min(n / 5, 3 * np.sqrt(n))), 5)
+    sorted_x = np.sort(x)
+    tail = sorted_x[-tail_n:]
+    threshold = sorted_x[-tail_n - 1] if tail_n < n else sorted_x[0]
+    exceedances = tail - threshold
+    exceedances = exceedances[exceedances > 0]
+    m = len(exceedances)
+    if m < 2:
+        return 0.0
+    # Pickands estimator (robust)
+    if m >= 4:
+        q = int(m / 4)
+        x_sorted = np.sort(exceedances)
+        k = (1.0 / np.log(2)) * np.log(
+            (x_sorted[-1] - x_sorted[-q - 1])
+            / max(x_sorted[-q - 1] - x_sorted[-2 * q - 1], 1e-10)
+        )
+        return float(k)
+    return 0.0

--- a/src/semla/bayes_results.py
+++ b/src/semla/bayes_results.py
@@ -181,7 +181,13 @@ class BayesianResults:
         I = jnp.eye(spec.n_vars)
         A_fixed = jnp.array(spec.A_values)
         S_fixed = jnp.array(spec.S_values)
-        obs_data = jnp.array(self._data)
+        # Center data when no mean structure (matches build_numpyro_model)
+        if spec.meanstructure and spec.m_values is not None:
+            obs_data = jnp.array(self._data)
+        else:
+            obs_data = jnp.array(
+                self._data - np.nanmean(self._data, axis=0, keepdims=True)
+            )
 
         m_fixed = None
         if spec.meanstructure and spec.m_values is not None:

--- a/src/semla/model.py
+++ b/src/semla/model.py
@@ -171,6 +171,10 @@ class Model:
         # Estimate
         estimator = kwargs.get("estimator", "ML").upper()
 
+        if estimator == "BAYES":
+            self._fit_bayes(data, kwargs)
+            return
+
         if missing == "fiml":
             from .fiml import estimate_fiml
             # FIML requires mean structure
@@ -195,7 +199,8 @@ class Model:
             est_result = estimate_dwls(self.spec, data)
         else:
             raise ValueError(
-                f"Unknown estimator '{estimator}'. Use 'ML', 'MLR', or 'DWLS'."
+                f"Unknown estimator '{estimator}'. "
+                "Use 'ML', 'MLR', 'DWLS', or 'bayes'."
             )
 
         # Build results
@@ -203,6 +208,33 @@ class Model:
         from .defined import extract_defined_params
         self._defined_params = extract_defined_params(self.tokens)
         self.results = ModelResults(est_result, defined_params=self._defined_params)
+
+    def _fit_bayes(self, data: pd.DataFrame, kwargs: dict):
+        """Run Bayesian estimation via NumPyro MCMC."""
+        try:
+            from .bayes import run_mcmc
+        except ImportError:
+            raise ImportError(
+                "numpyro is required for estimator='bayes'. "
+                "Install it with:  pip install semla[bayes]"
+            ) from None
+
+        obs_vars = self.spec.observed_vars
+        data_array = data[obs_vars].values.astype(float)
+
+        bayes_kwargs = {
+            "priors": kwargs.get("priors", None),
+            "num_warmup": kwargs.get("warmup", kwargs.get("num_warmup", 1000)),
+            "num_samples": kwargs.get("draws", kwargs.get("num_samples", 1000)),
+            "num_chains": kwargs.get("chains", kwargs.get("num_chains", 4)),
+            "seed": kwargs.get("seed", 0),
+            "target_accept_prob": kwargs.get("adapt_delta",
+                                             kwargs.get("target_accept_prob", 0.8)),
+            "adapt_convergence": kwargs.get("adapt_convergence", True),
+            "progress_bar": kwargs.get("progress_bar", True),
+        }
+
+        self.results = run_mcmc(self.spec, data_array, **bayes_kwargs)
 
     def summary(self) -> str:
         """Print and return a lavaan-style summary."""

--- a/src/semla/model.py
+++ b/src/semla/model.py
@@ -229,6 +229,7 @@ class Model:
             "num_chains": kwargs.get("chains", kwargs.get("num_chains", 4)),
             "cores": kwargs.get("cores", None),
             "seed": kwargs.get("seed", 0),
+            "positive_loadings": kwargs.get("positive_loadings", True),
             "target_accept_prob": kwargs.get("adapt_delta",
                                              kwargs.get("target_accept_prob", 0.8)),
             "adapt_convergence": kwargs.get("adapt_convergence", True),

--- a/src/semla/model.py
+++ b/src/semla/model.py
@@ -227,6 +227,7 @@ class Model:
             "num_warmup": kwargs.get("warmup", kwargs.get("num_warmup", 1000)),
             "num_samples": kwargs.get("draws", kwargs.get("num_samples", 1000)),
             "num_chains": kwargs.get("chains", kwargs.get("num_chains", 4)),
+            "cores": kwargs.get("cores", None),
             "seed": kwargs.get("seed", 0),
             "target_accept_prob": kwargs.get("adapt_delta",
                                              kwargs.get("target_accept_prob", 0.8)),

--- a/src/semla/prior_defaults.py
+++ b/src/semla/prior_defaults.py
@@ -1,0 +1,230 @@
+"""Data-adaptive and weak prior defaults for Bayesian SEM.
+
+Resolves user-supplied prior specifications (string presets, matrix-level
+overrides, per-parameter overrides) into a concrete prior for every free
+parameter in a :class:`~semla.specification.ModelSpecification`.
+
+Priority (lowest to highest):
+    1. Adaptive / weak defaults (base tier)
+    2. Matrix-level overrides  (e.g. ``{"loadings": Normal(0, 1)}``)
+    3. Per-parameter overrides (e.g. ``{"f1=~x2": Normal(0.7, 0.2)}``)
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+
+from .priors import (
+    Prior,
+    Normal,
+    StudentT,
+    HalfCauchy,
+    InverseGamma,
+    LKJ,
+    Gamma,
+)
+from .specification import ModelSpecification, ParamInfo
+
+# ── type aliases ────────────────────────────────────────────────────────
+PriorSpec = Union[str, dict[str, Prior], None]
+
+# ── matrix-level keys ───────────────────────────────────────────────────
+MATRIX_KEYS = {
+    "loadings",
+    "regressions",
+    "residual_variances",
+    "factor_variances",
+    "covariances",
+    "intercepts",
+}
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+def _param_key(p: ParamInfo) -> str:
+    """Return the canonical string key for a parameter (e.g. ``'f1=~x2'``)."""
+    return f"{p.lhs}{p.op}{p.rhs}"
+
+
+def _matrix_category(p: ParamInfo, spec: ModelSpecification) -> str:
+    """Classify a free parameter into one of the matrix-level categories."""
+    if p.op == "=~":
+        return "loadings"
+    if p.op == "~":
+        return "regressions"
+    if p.op == "~1":
+        return "intercepts"
+    # op == "~~"
+    if p.lhs == p.rhs:
+        if p.lhs in spec.latent_vars:
+            return "factor_variances"
+        return "residual_variances"
+    return "covariances"
+
+
+# ── adaptive defaults (brms-style, scaled by observed SDs) ─────────────
+
+def _observed_sds(spec: ModelSpecification, data: np.ndarray) -> dict[str, float]:
+    """Map each observed variable to its sample SD."""
+    sds: dict[str, float] = {}
+    for i, var in enumerate(spec.observed_vars):
+        col = data[:, i]
+        col_clean = col[~np.isnan(col)]
+        sds[var] = float(np.std(col_clean, ddof=1)) if len(col_clean) > 1 else 1.0
+    return sds
+
+
+def _adaptive_prior(
+    p: ParamInfo,
+    category: str,
+    obs_sds: dict[str, float],
+    spec: ModelSpecification,
+) -> Prior:
+    """Return a data-adaptive prior for a single free parameter.
+
+    Scaling follows the brms convention: use observed SDs to set prior
+    widths so that priors are weakly informative relative to the data
+    scale.
+    """
+    # median SD across all observed indicators as a scale reference
+    median_sd = float(np.median(list(obs_sds.values()))) if obs_sds else 1.0
+
+    if category == "loadings":
+        # Normal centred at 0, width ~ 2.5 * indicator SD
+        rhs_sd = obs_sds.get(p.rhs, median_sd)
+        return Normal(mu=0.0, sigma=2.5 * rhs_sd)
+
+    if category == "regressions":
+        return Normal(mu=0.0, sigma=2.5 * median_sd)
+
+    if category == "residual_variances":
+        var_sd = obs_sds.get(p.lhs, median_sd)
+        return InverseGamma(concentration=2.0, rate=var_sd ** 2)
+
+    if category == "factor_variances":
+        return InverseGamma(concentration=2.0, rate=median_sd ** 2)
+
+    if category == "covariances":
+        return Normal(mu=0.0, sigma=2.5 * median_sd ** 2)
+
+    if category == "intercepts":
+        var_sd = obs_sds.get(p.lhs, median_sd)
+        return Normal(mu=0.0, sigma=10.0 * var_sd)
+
+    # fallback
+    return Normal(mu=0.0, sigma=10.0)  # pragma: no cover
+
+
+# ── weak informative preset ────────────────────────────────────────────
+
+_WEAK_DEFAULTS: dict[str, Prior] = {
+    "loadings": Normal(mu=0.0, sigma=10.0),
+    "regressions": Normal(mu=0.0, sigma=10.0),
+    "residual_variances": InverseGamma(concentration=0.01, rate=0.01),
+    "factor_variances": InverseGamma(concentration=0.01, rate=0.01),
+    "covariances": Normal(mu=0.0, sigma=100.0),
+    "intercepts": Normal(mu=0.0, sigma=100.0),
+}
+
+
+def _weak_prior(category: str) -> Prior:
+    """Return a fixed wide (weak informative) prior."""
+    return _WEAK_DEFAULTS[category]
+
+
+# ── public API ──────────────────────────────────────────────────────────
+
+def resolve_priors(
+    spec: ModelSpecification,
+    data: np.ndarray,
+    priors: PriorSpec = None,
+) -> dict[str, Prior]:
+    """Resolve a user-supplied prior specification to a per-parameter dict.
+
+    Parameters
+    ----------
+    spec : ModelSpecification
+        The built RAM specification (must contain ``params``).
+    data : np.ndarray
+        Observed data matrix (n_obs × p_observed), columns matching
+        ``spec.observed_vars``.
+    priors : str, dict, or None
+        * ``None`` (default) — data-adaptive priors scaled by observed SDs.
+        * ``"weak"`` — fixed wide priors (InverseGamma(0.01, 0.01) for
+          variances, Normal(0, 10) for loadings, etc.).
+        * ``dict`` — mix of matrix-level and per-parameter overrides.
+          Matrix-level keys: ``"loadings"``, ``"regressions"``,
+          ``"residual_variances"``, ``"factor_variances"``,
+          ``"covariances"``, ``"intercepts"``.
+          Per-parameter keys use lavaan syntax: ``"f1=~x2"``.
+
+    Returns
+    -------
+    dict[str, Prior]
+        Mapping from parameter key (e.g. ``"f1=~x2"``) to a
+        :class:`~semla.priors.Prior` instance for every free parameter.
+    """
+    # separate overrides into tiers
+    matrix_overrides: dict[str, Prior] = {}
+    param_overrides: dict[str, Prior] = {}
+    use_weak = False
+
+    if isinstance(priors, str):
+        if priors.lower() == "weak":
+            use_weak = True
+        else:
+            raise ValueError(
+                f"Unknown prior preset: {priors!r}. Use 'weak' or a dict."
+            )
+    elif isinstance(priors, dict):
+        for key, val in priors.items():
+            if not isinstance(val, Prior):
+                raise TypeError(
+                    f"Prior for {key!r} must be a Prior instance, got {type(val).__name__}"
+                )
+            if key in MATRIX_KEYS:
+                matrix_overrides[key] = val
+            else:
+                param_overrides[key] = val
+
+    # pre-compute observed SDs for adaptive scaling
+    obs_sds = _observed_sds(spec, data) if not use_weak else {}
+
+    # resolve for every free parameter
+    result: dict[str, Prior] = {}
+    for p in spec.params:
+        if not p.free:
+            continue
+        key = _param_key(p)
+        category = _matrix_category(p, spec)
+
+        # tier 1: base default
+        if use_weak:
+            prior = _weak_prior(category)
+        else:
+            prior = _adaptive_prior(p, category, obs_sds, spec)
+
+        # tier 2: matrix-level override
+        if category in matrix_overrides:
+            prior = matrix_overrides[category]
+
+        # tier 3: per-parameter override
+        if key in param_overrides:
+            prior = param_overrides[key]
+
+        result[key] = prior
+
+    # warn about unused per-parameter overrides
+    used_keys = set(result.keys())
+    unused = set(param_overrides.keys()) - used_keys
+    if unused:
+        import warnings
+        warnings.warn(
+            f"Prior overrides for unknown parameters ignored: {unused}",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    return result

--- a/src/semla/prior_defaults.py
+++ b/src/semla/prior_defaults.py
@@ -120,12 +120,12 @@ def _adaptive_prior(
 # ── weak informative preset ────────────────────────────────────────────
 
 _WEAK_DEFAULTS: dict[str, Prior] = {
-    "loadings": Normal(mu=0.0, sigma=10.0),
-    "regressions": Normal(mu=0.0, sigma=10.0),
-    "residual_variances": InverseGamma(concentration=0.01, rate=0.01),
-    "factor_variances": InverseGamma(concentration=0.01, rate=0.01),
-    "covariances": Normal(mu=0.0, sigma=100.0),
-    "intercepts": Normal(mu=0.0, sigma=100.0),
+    "loadings": Normal(mu=0.0, sigma=5.0),
+    "regressions": Normal(mu=0.0, sigma=5.0),
+    "residual_variances": InverseGamma(concentration=2.0, rate=1.0),
+    "factor_variances": InverseGamma(concentration=2.0, rate=1.0),
+    "covariances": Normal(mu=0.0, sigma=10.0),
+    "intercepts": Normal(mu=0.0, sigma=20.0),
 }
 
 

--- a/src/semla/priors.py
+++ b/src/semla/priors.py
@@ -1,0 +1,245 @@
+"""Prior distribution classes for Bayesian SEM estimation.
+
+Semla-native dataclasses that wrap NumPyro distributions internally.
+Each prior has a ``to_numpyro()`` method that returns the corresponding
+NumPyro distribution object for use in probabilistic models.
+
+Example
+-------
+>>> from semla.priors import Normal, HalfCauchy, LKJ
+>>> Normal(mu=0, sigma=10).to_numpyro()
+>>> HalfCauchy(scale=2.5).to_numpyro()
+>>> LKJ(dim=3, concentration=2.0).to_numpyro()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def _import_numpyro_dist():
+    """Lazy-import numpyro.distributions, raising a clear error if missing."""
+    try:
+        import numpyro.distributions as dist
+
+        return dist
+    except ImportError:
+        raise ImportError(
+            "numpyro is required for Bayesian estimation. "
+            "Install it with:  pip install semla[bayes]"
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Prior:
+    """Base class for all prior distributions."""
+
+    def to_numpyro(self) -> Any:
+        """Return the corresponding ``numpyro.distributions`` object."""
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Unbounded (support on the real line)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Normal(Prior):
+    """Normal (Gaussian) prior.  Support: (-inf, inf)."""
+
+    mu: float = 0.0
+    sigma: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Normal(self.mu, self.sigma)
+
+
+@dataclass
+class StudentT(Prior):
+    """Student-t prior.  Support: (-inf, inf)."""
+
+    df: float = 3.0
+    loc: float = 0.0
+    scale: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.StudentT(self.df, self.loc, self.scale)
+
+
+@dataclass
+class Cauchy(Prior):
+    """Cauchy prior.  Support: (-inf, inf)."""
+
+    loc: float = 0.0
+    scale: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Cauchy(self.loc, self.scale)
+
+
+@dataclass
+class Uniform(Prior):
+    """Uniform prior.  Support: [low, high]."""
+
+    low: float = 0.0
+    high: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Uniform(self.low, self.high)
+
+
+@dataclass
+class Laplace(Prior):
+    """Laplace prior.  Support: (-inf, inf)."""
+
+    loc: float = 0.0
+    scale: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Laplace(self.loc, self.scale)
+
+
+# ---------------------------------------------------------------------------
+# Positive (support on the positive reals)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class HalfCauchy(Prior):
+    """Half-Cauchy prior.  Support: (0, inf)."""
+
+    scale: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.HalfCauchy(self.scale)
+
+
+@dataclass
+class HalfNormal(Prior):
+    """Half-Normal prior.  Support: (0, inf)."""
+
+    scale: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.HalfNormal(self.scale)
+
+
+@dataclass
+class InverseGamma(Prior):
+    """Inverse-Gamma prior.  Support: (0, inf)."""
+
+    concentration: float = 1.0
+    rate: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.InverseGamma(self.concentration, self.rate)
+
+
+@dataclass
+class Exponential(Prior):
+    """Exponential prior.  Support: (0, inf)."""
+
+    rate: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Exponential(self.rate)
+
+
+@dataclass
+class Gamma(Prior):
+    """Gamma prior.  Support: (0, inf)."""
+
+    concentration: float = 1.0
+    rate: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Gamma(self.concentration, self.rate)
+
+
+@dataclass
+class LogNormal(Prior):
+    """Log-Normal prior.  Support: (0, inf)."""
+
+    loc: float = 0.0
+    scale: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.LogNormal(self.loc, self.scale)
+
+
+# ---------------------------------------------------------------------------
+# Correlations
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LKJ(Prior):
+    """LKJ prior for correlation matrices.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the correlation matrix.
+    concentration : float
+        Concentration parameter (eta).  ``concentration=1`` is uniform
+        over correlation matrices; larger values concentrate toward the
+        identity matrix.
+    """
+
+    dim: int = 2
+    concentration: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.LKJCholesky(self.dim, self.concentration)
+
+
+@dataclass
+class Beta(Prior):
+    """Beta prior.  Support: (0, 1).  Useful for correlations via transform."""
+
+    concentration1: float = 1.0
+    concentration0: float = 1.0
+
+    def to_numpyro(self):
+        dist = _import_numpyro_dist()
+        return dist.Beta(self.concentration1, self.concentration0)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "Prior",
+    # Unbounded
+    "Normal",
+    "StudentT",
+    "Cauchy",
+    "Uniform",
+    "Laplace",
+    # Positive
+    "HalfCauchy",
+    "HalfNormal",
+    "InverseGamma",
+    "Exponential",
+    "Gamma",
+    "LogNormal",
+    # Correlations
+    "LKJ",
+    "Beta",
+]

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -1,0 +1,222 @@
+"""Tests for semla.bayes — NumPyro model builder for Bayesian SEM."""
+
+import numpy as np
+import pytest
+
+numpyro = pytest.importorskip("numpyro")
+import jax
+import jax.numpy as jnp
+
+from semla.specification import build_specification, ParamInfo
+from semla.syntax import parse_syntax
+from semla.priors import Normal, InverseGamma
+from semla.bayes import (
+    build_numpyro_model,
+    _build_param_table,
+    run_mcmc,
+    MCMCResult,
+    _effective_sample_size,
+    _rhat,
+)
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def simple_cfa():
+    """Simple 2-factor CFA with synthetic data from known parameters."""
+    rng = np.random.default_rng(42)
+    n = 200
+
+    # True factor scores
+    f1 = rng.normal(0, 1, n)
+    f2 = rng.normal(0, 1, n)
+
+    # True loadings and residuals
+    x1 = 1.0 * f1 + rng.normal(0, 0.5, n)
+    x2 = 0.8 * f1 + rng.normal(0, 0.5, n)
+    x3 = 0.6 * f1 + rng.normal(0, 0.5, n)
+    x4 = 1.0 * f2 + rng.normal(0, 0.5, n)
+    x5 = 0.9 * f2 + rng.normal(0, 0.5, n)
+    x6 = 0.7 * f2 + rng.normal(0, 0.5, n)
+
+    data = np.column_stack([x1, x2, x3, x4, x5, x6])
+
+    syntax = """
+        f1 =~ x1 + x2 + x3
+        f2 =~ x4 + x5 + x6
+    """
+    tokens = parse_syntax(syntax)
+    observed = ["x1", "x2", "x3", "x4", "x5", "x6"]
+    spec = build_specification(tokens, observed)
+
+    return spec, data
+
+
+# ── param table tests ───────────────────────────────────────────────────
+
+class TestParamTable:
+    def test_correct_number_of_effective_params(self, simple_cfa):
+        spec, data = simple_cfa
+        a_params, s_params, m_params, n_eff, keys = _build_param_table(spec)
+        assert n_eff == spec.n_free
+
+    def test_param_keys_length(self, simple_cfa):
+        spec, data = simple_cfa
+        _, _, _, n_eff, keys = _build_param_table(spec)
+        assert len(keys) == n_eff
+
+    def test_a_params_are_loadings(self, simple_cfa):
+        spec, data = simple_cfa
+        a_params, _, _, _, _ = _build_param_table(spec)
+        # Should have 4 free loadings (2 per factor minus fixed first)
+        assert len(a_params) == 4
+        for key, r, c, ridx, eidx in a_params:
+            assert "=~" in key
+
+    def test_s_params_include_variances_and_covariance(self, simple_cfa):
+        spec, data = simple_cfa
+        _, s_params, _, _, _ = _build_param_table(spec)
+        # 6 residual vars + 2 factor vars + 1 factor covariance = 9
+        assert len(s_params) == 9
+
+
+# ── model build tests ──────────────────────────────────────────────────
+
+class TestBuildModel:
+    def test_returns_callable(self, simple_cfa):
+        spec, data = simple_cfa
+        model_fn, prior_dict, param_keys = build_numpyro_model(spec, data)
+        assert callable(model_fn)
+
+    def test_prior_dict_covers_all_free(self, simple_cfa):
+        spec, data = simple_cfa
+        _, prior_dict, param_keys = build_numpyro_model(spec, data)
+        n_free = sum(1 for p in spec.params if p.free)
+        assert len(prior_dict) == n_free
+
+    def test_param_keys_match_prior_dict(self, simple_cfa):
+        spec, data = simple_cfa
+        _, prior_dict, param_keys = build_numpyro_model(spec, data)
+        for key in param_keys:
+            assert key in prior_dict
+
+    def test_model_traces_without_error(self, simple_cfa):
+        """Model function runs under numpyro.handlers.trace."""
+        spec, data = simple_cfa
+        model_fn, _, _ = build_numpyro_model(spec, data)
+        import numpyro.handlers as handlers
+        with handlers.seed(rng_seed=0):
+            trace = handlers.trace(model_fn).get_trace()
+        assert "obs" in trace
+
+    def test_custom_priors(self, simple_cfa):
+        spec, data = simple_cfa
+        model_fn, prior_dict, _ = build_numpyro_model(
+            spec, data, priors={"loadings": Normal(0, 5)}
+        )
+        for key, prior in prior_dict.items():
+            if "=~" in key:
+                assert isinstance(prior, Normal)
+                assert prior.sigma == 5
+
+
+# ── mean structure ──────────────────────────────────────────────────────
+
+class TestMeanStructure:
+    def test_model_with_meanstructure(self):
+        syntax = """
+            f1 =~ x1 + x2 + x3
+        """
+        tokens = parse_syntax(syntax)
+        observed = ["x1", "x2", "x3"]
+        spec = build_specification(tokens, observed, meanstructure=True)
+
+        rng = np.random.default_rng(0)
+        data = rng.normal(5, 2, (100, 3))
+
+        model_fn, prior_dict, param_keys = build_numpyro_model(spec, data)
+
+        # Should include intercept parameters
+        intercept_keys = [k for k in param_keys if "~1" in k]
+        assert len(intercept_keys) == 3
+
+        # Trace should work
+        import numpyro.handlers as handlers
+        with handlers.seed(rng_seed=0):
+            trace = handlers.trace(model_fn).get_trace()
+        assert "obs" in trace
+
+
+# ── equality constraints ────────────────────────────────────────────────
+
+class TestEqualityConstraints:
+    def test_constrained_params_share_sample(self):
+        syntax = """
+            f1 =~ x1 + c1*x2 + c1*x3
+        """
+        tokens = parse_syntax(syntax)
+        observed = ["x1", "x2", "x3"]
+        spec = build_specification(tokens, observed)
+
+        rng = np.random.default_rng(0)
+        data = rng.normal(0, 1, (100, 3))
+
+        model_fn, prior_dict, param_keys = build_numpyro_model(spec, data)
+
+        # c1 constraint means x2 and x3 loadings share a parameter
+        # So n_effective should be less than n_raw_free
+        loading_keys = [k for k in param_keys if "=~" in k]
+        assert len(loading_keys) == 1  # only one unique loading (c1)
+
+
+# ── diagnostics helpers ─────────────────────────────────────────────────
+
+class TestDiagnostics:
+    def test_ess_iid_sample(self):
+        rng = np.random.default_rng(42)
+        x = rng.normal(0, 1, 1000)
+        ess = _effective_sample_size(x)
+        # For iid samples, ESS should be close to n
+        assert ess > 500
+
+    def test_ess_constant(self):
+        x = np.ones(100)
+        ess = _effective_sample_size(x)
+        assert ess == 100.0
+
+    def test_rhat_single_chain(self):
+        x = np.random.randn(100)
+        r = _rhat(x, 1)
+        assert np.isnan(r)
+
+    def test_rhat_converged(self):
+        rng = np.random.default_rng(42)
+        # 4 chains of iid draws from same distribution
+        x = rng.normal(0, 1, 4000)
+        r = _rhat(x, 4)
+        assert 0.9 < r < 1.1
+
+
+# ── MCMC smoke test (short run) ────────────────────────────────────────
+
+class TestMCMCSmoke:
+    @pytest.mark.slow
+    def test_short_mcmc_runs(self, simple_cfa):
+        """Very short MCMC run to verify the pipeline works end-to-end."""
+        spec, data = simple_cfa
+        result = run_mcmc(
+            spec, data,
+            num_warmup=50,
+            num_samples=50,
+            num_chains=1,
+            seed=0,
+            progress_bar=False,
+        )
+        assert isinstance(result, MCMCResult)
+        assert len(result.samples) > 0
+
+        df = result.summary()
+        assert "mean" in df.columns
+        assert "rhat" in df.columns
+        assert len(df) == spec.n_free

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -14,10 +14,10 @@ from semla.bayes import (
     build_numpyro_model,
     _build_param_table,
     run_mcmc,
-    MCMCResult,
     _effective_sample_size,
     _rhat,
 )
+from semla.bayes_results import BayesianResults
 
 
 # ── fixtures ────────────────────────────────────────────────────────────
@@ -213,7 +213,7 @@ class TestMCMCSmoke:
             seed=0,
             progress_bar=False,
         )
-        assert isinstance(result, MCMCResult)
+        assert isinstance(result, BayesianResults)
         assert len(result.samples) > 0
 
         df = result.summary()

--- a/tests/test_bayes_adaptive.py
+++ b/tests/test_bayes_adaptive.py
@@ -1,0 +1,171 @@
+"""Tests for adaptive convergence (#30) and BayesianResults (#31)."""
+
+import numpy as np
+import pytest
+
+numpyro = pytest.importorskip("numpyro")
+
+from semla.specification import build_specification
+from semla.syntax import parse_syntax
+from semla.bayes import (
+    _max_rhat,
+    _divergence_stats,
+    _rhat,
+    _effective_sample_size,
+)
+from semla.bayes_results import BayesianResults, _pareto_k_estimate
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def simple_cfa_data():
+    """Simple CFA with known parameters."""
+    rng = np.random.default_rng(42)
+    n = 200
+    f1 = rng.normal(0, 1, n)
+    f2 = rng.normal(0, 1, n)
+    x1 = 1.0 * f1 + rng.normal(0, 0.5, n)
+    x2 = 0.8 * f1 + rng.normal(0, 0.5, n)
+    x3 = 0.6 * f1 + rng.normal(0, 0.5, n)
+    x4 = 1.0 * f2 + rng.normal(0, 0.5, n)
+    x5 = 0.9 * f2 + rng.normal(0, 0.5, n)
+    x6 = 0.7 * f2 + rng.normal(0, 0.5, n)
+    data = np.column_stack([x1, x2, x3, x4, x5, x6])
+
+    syntax = "f1 =~ x1 + x2 + x3\nf2 =~ x4 + x5 + x6"
+    tokens = parse_syntax(syntax)
+    spec = build_specification(tokens, ["x1", "x2", "x3", "x4", "x5", "x6"])
+    return spec, data
+
+
+# ── adaptive convergence helpers ────────────────────────────────────────
+
+class TestMaxRhat:
+    def test_converged_samples(self):
+        rng = np.random.default_rng(42)
+        samples = {
+            "a": rng.normal(0, 1, 4000),
+            "b": rng.normal(0, 1, 4000),
+        }
+        r = _max_rhat(samples, 4)
+        assert r < 1.05
+
+    def test_skips_obs_key(self):
+        rng = np.random.default_rng(42)
+        samples = {
+            "a": rng.normal(0, 1, 4000),
+            "obs": rng.normal(0, 1, (4000, 6)),  # observation likelihood
+        }
+        r = _max_rhat(samples, 4)
+        assert r < 1.05
+
+
+class TestDivergenceStats:
+    def test_no_divergences_returns_zero(self):
+        """When mcmc has no diverging field, return 0."""
+        class FakeMCMC:
+            def get_extra_fields(self):
+                return {}
+        n, pct = _divergence_stats(FakeMCMC())
+        assert n == 0
+        assert pct == 0.0
+
+    def test_with_divergences(self):
+        class FakeMCMC:
+            def get_extra_fields(self):
+                div = np.zeros(1000, dtype=bool)
+                div[:30] = True  # 3% divergent
+                return {"diverging": div}
+        n, pct = _divergence_stats(FakeMCMC())
+        assert n == 30
+        assert abs(pct - 3.0) < 0.1
+
+
+# ── BayesianResults diagnostics ─────────────────────────────────────────
+
+class TestParetoK:
+    def test_light_tail(self):
+        rng = np.random.default_rng(42)
+        x = rng.exponential(1, 1000)
+        k = _pareto_k_estimate(x)
+        # Should return a finite value for light-tailed data
+        assert np.isfinite(k)
+
+    def test_constant_returns_zero(self):
+        x = np.ones(100)
+        k = _pareto_k_estimate(x)
+        assert k == 0.0
+
+
+# ── MCMC integration (short run) ───────────────────────────────────────
+
+class TestBayesianResultsIntegration:
+    @pytest.fixture(scope="class")
+    def bayes_result(self, simple_cfa_data):
+        from semla.bayes import run_mcmc
+        spec, data = simple_cfa_data
+        return run_mcmc(
+            spec, data,
+            num_warmup=50,
+            num_samples=50,
+            num_chains=2,
+            seed=0,
+            adapt_convergence=False,
+            progress_bar=False,
+        )
+
+    def test_is_bayesian_results(self, bayes_result):
+        assert isinstance(bayes_result, BayesianResults)
+
+    def test_draws_shape(self, bayes_result, simple_cfa_data):
+        spec, _ = simple_cfa_data
+        df = bayes_result.draws()
+        assert df.shape[0] == 100  # 2 chains * 50 draws
+        assert df.shape[1] == spec.n_free
+
+    def test_estimates_columns(self, bayes_result):
+        est = bayes_result.estimates()
+        for col in ["lhs", "op", "rhs", "mean", "median", "sd",
+                     "ci.lower", "ci.upper", "rhat", "ess"]:
+            assert col in est.columns
+
+    def test_diagnostics_keys(self, bayes_result):
+        diag = bayes_result.diagnostics()
+        for key in ["divergences", "divergence_pct", "min_ess",
+                     "max_rhat", "num_chains", "num_warmup", "num_samples"]:
+            assert key in diag
+
+    def test_summary_returns_string(self, bayes_result):
+        s = bayes_result.summary()
+        assert isinstance(s, str)
+        assert "Bayesian SEM Results" in s
+        assert "Bayes" in s
+
+    def test_converged_property(self, bayes_result):
+        # With 50 draws we may or may not converge, just check it doesn't crash
+        assert isinstance(bayes_result.converged, bool)
+
+    def test_fit_indices_returns_waic(self, bayes_result):
+        fi = bayes_result.fit_indices()
+        assert "waic" in fi
+        assert "p_waic" in fi
+
+
+class TestAdaptiveRun:
+    """Test that adaptive convergence doesn't crash (short run)."""
+
+    def test_adaptive_runs(self, simple_cfa_data):
+        from semla.bayes import run_mcmc
+        spec, data = simple_cfa_data
+        result = run_mcmc(
+            spec, data,
+            num_warmup=30,
+            num_samples=30,
+            num_chains=2,
+            seed=42,
+            adapt_convergence=True,
+            max_retries=1,
+            progress_bar=False,
+        )
+        assert isinstance(result, BayesianResults)

--- a/tests/test_bayes_integration.py
+++ b/tests/test_bayes_integration.py
@@ -1,0 +1,125 @@
+"""Integration test: wire estimator='bayes' into cfa()/sem() (#32)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+numpyro = pytest.importorskip("numpyro")
+
+from semla import cfa, sem
+from semla.bayes_results import BayesianResults
+
+
+@pytest.fixture(scope="module")
+def cfa_data():
+    """Synthetic CFA data as a DataFrame."""
+    rng = np.random.default_rng(42)
+    n = 200
+    f1 = rng.normal(0, 1, n)
+    f2 = rng.normal(0, 1, n)
+    return pd.DataFrame({
+        "x1": 1.0 * f1 + rng.normal(0, 0.5, n),
+        "x2": 0.8 * f1 + rng.normal(0, 0.5, n),
+        "x3": 0.6 * f1 + rng.normal(0, 0.5, n),
+        "x4": 1.0 * f2 + rng.normal(0, 0.5, n),
+        "x5": 0.9 * f2 + rng.normal(0, 0.5, n),
+        "x6": 0.7 * f2 + rng.normal(0, 0.5, n),
+    })
+
+
+class TestCfaBayes:
+    @pytest.fixture(scope="class")
+    def fit(self, cfa_data):
+        return cfa(
+            "f1 =~ x1 + x2 + x3\nf2 =~ x4 + x5 + x6",
+            data=cfa_data,
+            estimator="bayes",
+            warmup=30,
+            draws=30,
+            chains=2,
+            seed=0,
+            adapt_convergence=False,
+            progress_bar=False,
+        )
+
+    def test_returns_model(self, fit):
+        from semla.model import Model
+        assert isinstance(fit, Model)
+
+    def test_results_are_bayesian(self, fit):
+        assert isinstance(fit.results, BayesianResults)
+
+    def test_summary_works(self, fit):
+        s = fit.summary()
+        assert "Bayesian" in s
+
+    def test_estimates_works(self, fit):
+        est = fit.estimates()
+        assert len(est) > 0
+        assert "mean" in est.columns
+
+    def test_fit_indices_works(self, fit):
+        fi = fit.fit_indices()
+        assert "waic" in fi
+
+    def test_converged_attr(self, fit):
+        assert isinstance(fit.converged, bool)
+
+
+class TestSemBayes:
+    def test_sem_bayes_runs(self, cfa_data):
+        fit = sem(
+            "f1 =~ x1 + x2 + x3\nf2 =~ x4 + x5 + x6\nf2 ~ f1",
+            data=cfa_data,
+            estimator="bayes",
+            warmup=30,
+            draws=30,
+            chains=2,
+            seed=0,
+            adapt_convergence=False,
+            progress_bar=False,
+        )
+        assert isinstance(fit.results, BayesianResults)
+
+
+class TestBayesWithPriors:
+    def test_weak_priors(self, cfa_data):
+        fit = cfa(
+            "f1 =~ x1 + x2 + x3\nf2 =~ x4 + x5 + x6",
+            data=cfa_data,
+            estimator="bayes",
+            priors="weak",
+            warmup=30,
+            draws=30,
+            chains=2,
+            seed=0,
+            adapt_convergence=False,
+            progress_bar=False,
+        )
+        assert isinstance(fit.results, BayesianResults)
+
+    def test_custom_priors(self, cfa_data):
+        from semla.priors import Normal
+        fit = cfa(
+            "f1 =~ x1 + x2 + x3\nf2 =~ x4 + x5 + x6",
+            data=cfa_data,
+            estimator="bayes",
+            priors={"loadings": Normal(0, 5)},
+            warmup=30,
+            draws=30,
+            chains=2,
+            seed=0,
+            adapt_convergence=False,
+            progress_bar=False,
+        )
+        assert isinstance(fit.results, BayesianResults)
+
+
+class TestBayesErrorHandling:
+    def test_unknown_estimator(self, cfa_data):
+        with pytest.raises(ValueError, match="Unknown estimator"):
+            cfa(
+                "f1 =~ x1 + x2 + x3",
+                data=cfa_data,
+                estimator="unknown",
+            )

--- a/tests/test_bayes_validation.py
+++ b/tests/test_bayes_validation.py
@@ -1,0 +1,313 @@
+"""Validation: compare Bayesian posterior means against ML point estimates.
+
+With weak/diffuse priors and sufficient draws, Bayesian posterior means
+should converge to ML estimates. This validates the entire Bayesian pipeline
+end-to-end against the well-tested frequentist estimator.
+
+These tests use real MCMC sampling and are slow (~30-60s each).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+numpyro = pytest.importorskip("numpyro")
+
+from semla import cfa, sem
+from semla.datasets import HolzingerSwineford1939
+from semla.priors import Normal, InverseGamma
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+HS_SYNTAX = """
+    visual  =~ x1 + x2 + x3
+    textual =~ x4 + x5 + x6
+    speed   =~ x7 + x8 + x9
+"""
+
+SEM_SYNTAX = """
+    visual  =~ x1 + x2 + x3
+    textual =~ x4 + x5 + x6
+    speed   =~ x7 + x8 + x9
+    speed ~ visual + textual
+    visual ~~ textual
+"""
+
+
+@pytest.fixture(scope="module")
+def hs_data():
+    return HolzingerSwineford1939()
+
+
+@pytest.fixture(scope="module")
+def ml_cfa(hs_data):
+    """ML CFA fit on Holzinger-Swineford."""
+    return cfa(HS_SYNTAX, data=hs_data)
+
+
+@pytest.fixture(scope="module")
+def bayes_cfa(hs_data):
+    """Bayesian CFA fit on Holzinger-Swineford with adaptive priors."""
+    return cfa(
+        HS_SYNTAX,
+        data=hs_data,
+        estimator="bayes",
+        warmup=1000,
+        draws=3000,
+        chains=4,
+        seed=42,
+        adapt_convergence=False,
+        progress_bar=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def ml_sem(hs_data):
+    """ML SEM fit."""
+    return sem(SEM_SYNTAX, data=hs_data)
+
+
+@pytest.fixture(scope="module")
+def bayes_sem(hs_data):
+    """Bayesian SEM fit with adaptive priors and longer warmup."""
+    return sem(
+        SEM_SYNTAX,
+        data=hs_data,
+        estimator="bayes",
+        warmup=2000,
+        draws=4000,
+        chains=4,
+        seed=42,
+        adapt_delta=0.95,
+        adapt_convergence=False,
+        progress_bar=False,
+    )
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+def _compare_estimates(ml_fit, bayes_fit, atol_loadings=0.15, atol_variances=0.2):
+    """Compare ML and Bayesian parameter estimates.
+
+    Returns a DataFrame with columns: param, ml_est, bayes_mean, diff, category.
+    Asserts that differences are within tolerance.
+    """
+    ml_est = ml_fit.estimates()
+    ml_free = ml_est[ml_est["free"]].copy()
+
+    bayes_est = bayes_fit.estimates()
+
+    rows = []
+    for _, ml_row in ml_free.iterrows():
+        key = f"{ml_row['lhs']}{ml_row['op']}{ml_row['rhs']}"
+        # Find matching Bayesian estimate
+        match = bayes_est[
+            (bayes_est["lhs"] == ml_row["lhs"]) &
+            (bayes_est["op"] == ml_row["op"]) &
+            (bayes_est["rhs"] == ml_row["rhs"])
+        ]
+        if match.empty:
+            continue
+
+        bayes_mean = match.iloc[0]["mean"]
+        ml_val = ml_row["est"]
+        diff = abs(bayes_mean - ml_val)
+        category = match.iloc[0].get("category", "unknown")
+
+        rows.append({
+            "param": key,
+            "ml_est": ml_val,
+            "bayes_mean": bayes_mean,
+            "diff": diff,
+            "category": category,
+        })
+
+    return pd.DataFrame(rows)
+
+
+# ── CFA validation ─────────────────────────────────────────────────────
+
+class TestCFAValidation:
+    """Compare 3-factor CFA: Bayesian vs ML on Holzinger-Swineford."""
+
+    def test_bayes_converged(self, bayes_cfa):
+        diag = bayes_cfa.results.diagnostics()
+        # With 2000 draws and 4 chains, should converge
+        assert diag["max_rhat"] < 1.05, (
+            f"Bayesian CFA did not converge: max R-hat = {diag['max_rhat']:.3f}"
+        )
+
+    def test_loadings_close_to_ml(self, ml_cfa, bayes_cfa):
+        comp = _compare_estimates(ml_cfa, bayes_cfa)
+        loadings = comp[comp["category"] == "loadings"]
+
+        for _, row in loadings.iterrows():
+            assert row["diff"] < 0.15, (
+                f"Loading {row['param']}: ML={row['ml_est']:.3f}, "
+                f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
+            )
+
+    def test_variances_close_to_ml(self, ml_cfa, bayes_cfa):
+        comp = _compare_estimates(ml_cfa, bayes_cfa)
+        variances = comp[comp["category"].isin(
+            ["residual_variances", "factor_variances"]
+        )]
+
+        for _, row in variances.iterrows():
+            # Variances can differ more due to prior influence
+            assert row["diff"] < 0.3, (
+                f"Variance {row['param']}: ML={row['ml_est']:.3f}, "
+                f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
+            )
+
+    def test_covariances_close_to_ml(self, ml_cfa, bayes_cfa):
+        comp = _compare_estimates(ml_cfa, bayes_cfa)
+        covs = comp[comp["category"] == "covariances"]
+
+        for _, row in covs.iterrows():
+            assert row["diff"] < 0.15, (
+                f"Covariance {row['param']}: ML={row['ml_est']:.3f}, "
+                f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
+            )
+
+    def test_ml_within_bayes_ci(self, ml_cfa, bayes_cfa):
+        """ML point estimates should fall within Bayesian 95% CIs."""
+        ml_est = ml_cfa.estimates()
+        ml_free = ml_est[ml_est["free"]]
+        bayes_est = bayes_cfa.results.estimates()
+
+        n_within = 0
+        n_total = 0
+        for _, ml_row in ml_free.iterrows():
+            match = bayes_est[
+                (bayes_est["lhs"] == ml_row["lhs"]) &
+                (bayes_est["op"] == ml_row["op"]) &
+                (bayes_est["rhs"] == ml_row["rhs"])
+            ]
+            if match.empty:
+                continue
+
+            n_total += 1
+            ci_low = match.iloc[0]["ci.lower"]
+            ci_high = match.iloc[0]["ci.upper"]
+            if ci_low <= ml_row["est"] <= ci_high:
+                n_within += 1
+
+        # At least 80% of ML estimates should fall within Bayesian CIs
+        coverage = n_within / n_total if n_total > 0 else 0
+        assert coverage >= 0.80, (
+            f"Only {n_within}/{n_total} ({coverage:.0%}) ML estimates "
+            f"fall within Bayesian 95% CIs"
+        )
+
+    def test_bayes_summary_runs(self, bayes_cfa):
+        """Summary should print without error."""
+        s = bayes_cfa.summary()
+        assert "Bayesian SEM Results" in s
+        assert "visual" in s or "x1" in s
+
+    def test_bayes_diagnostics(self, bayes_cfa):
+        diag = bayes_cfa.results.diagnostics()
+        assert diag["num_chains"] == 4
+        assert diag["num_samples"] == 3000
+        assert diag["min_ess"] > 0
+
+
+# ── SEM validation ──────────────────────────────────────────────────────
+
+@pytest.mark.xfail(
+    reason="Latent regression models suffer from sign-flipping non-identifiability "
+           "that requires sign constraints or reparameterization (see #34)",
+    strict=False,
+)
+class TestSEMValidation:
+    """Compare SEM with regressions: Bayesian vs ML.
+
+    Structural models with latent regressions are harder to sample due
+    to sign-flipping non-identifiability.  These tests are expected to
+    fail until sign constraints are implemented.
+    """
+
+    def test_bayes_converged(self, bayes_sem):
+        diag = bayes_sem.results.diagnostics()
+        assert diag["max_rhat"] < 1.10, (
+            f"Bayesian SEM did not converge: max R-hat = {diag['max_rhat']:.3f}"
+        )
+
+    def test_regression_coefficients_close(self, ml_sem, bayes_sem):
+        comp = _compare_estimates(ml_sem, bayes_sem)
+        regs = comp[comp["category"] == "regressions"]
+
+        for _, row in regs.iterrows():
+            assert row["diff"] < 0.3, (
+                f"Regression {row['param']}: ML={row['ml_est']:.3f}, "
+                f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
+            )
+
+    def test_loadings_close(self, ml_sem, bayes_sem):
+        comp = _compare_estimates(ml_sem, bayes_sem)
+        loadings = comp[comp["category"] == "loadings"]
+
+        for _, row in loadings.iterrows():
+            assert row["diff"] < 0.25, (
+                f"Loading {row['param']}: ML={row['ml_est']:.3f}, "
+                f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
+            )
+
+
+# ── WAIC sanity checks ─────────────────────────────────────────────────
+
+class TestWAICSanity:
+    """WAIC should be a reasonable number and p_waic should be positive."""
+
+    def test_waic_is_finite(self, bayes_cfa):
+        w = bayes_cfa.results.waic()
+        assert np.isfinite(w["waic"]), f"WAIC is not finite: {w['waic']}"
+
+    def test_p_waic_positive(self, bayes_cfa):
+        w = bayes_cfa.results.waic()
+        assert w["p_waic"] > 0, f"p_WAIC should be positive, got {w['p_waic']}"
+
+    def test_p_waic_reasonable(self, bayes_cfa):
+        """p_WAIC should be roughly in the neighborhood of n_free params."""
+        w = bayes_cfa.results.waic()
+        n_free = bayes_cfa.results.spec.n_free
+        # p_waic should be in a reasonable range
+        assert w["p_waic"] < n_free * 10, (
+            f"p_WAIC={w['p_waic']:.1f} seems too large for "
+            f"{n_free} free parameters"
+        )
+
+
+# ── LOO sanity checks ──────────────────────────────────────────────────
+
+class TestLOOSanity:
+    def test_loo_is_finite(self, bayes_cfa):
+        l = bayes_cfa.results.loo()
+        assert np.isfinite(l["loo"]), f"LOO is not finite: {l['loo']}"
+
+    def test_loo_se_positive(self, bayes_cfa):
+        l = bayes_cfa.results.loo()
+        assert l["se"] > 0
+
+
+# ── Print comparison table ──────────────────────────────────────────────
+
+class TestComparisonReport:
+    """Not a real test — prints a comparison table for visual inspection."""
+
+    def test_print_comparison(self, ml_cfa, bayes_cfa):
+        comp = _compare_estimates(ml_cfa, bayes_cfa)
+        print("\n" + "=" * 70)
+        print("ML vs Bayesian Parameter Comparison (3-factor CFA)")
+        print("=" * 70)
+        print(f"{'Parameter':<20s} {'ML':>10s} {'Bayes':>10s} {'Diff':>8s} {'Category':<20s}")
+        print("-" * 70)
+        for _, row in comp.iterrows():
+            print(
+                f"{row['param']:<20s} {row['ml_est']:>10.3f} "
+                f"{row['bayes_mean']:>10.3f} {row['diff']:>8.3f} "
+                f"{row['category']:<20s}"
+            )
+        print("=" * 70)

--- a/tests/test_bayes_validation.py
+++ b/tests/test_bayes_validation.py
@@ -216,22 +216,16 @@ class TestCFAValidation:
 
 # ── SEM validation ──────────────────────────────────────────────────────
 
-@pytest.mark.xfail(
-    reason="Latent regression models suffer from sign-flipping non-identifiability "
-           "that requires sign constraints or reparameterization (see #34)",
-    strict=False,
-)
 class TestSEMValidation:
     """Compare SEM with regressions: Bayesian vs ML.
 
-    Structural models with latent regressions are harder to sample due
-    to sign-flipping non-identifiability.  These tests are expected to
-    fail until sign constraints are implemented.
+    Uses positive loading constraints to prevent sign-flipping.
+    Tolerances are slightly wider than CFA due to structural complexity.
     """
 
     def test_bayes_converged(self, bayes_sem):
         diag = bayes_sem.results.diagnostics()
-        assert diag["max_rhat"] < 1.10, (
+        assert diag["max_rhat"] < 1.05, (
             f"Bayesian SEM did not converge: max R-hat = {diag['max_rhat']:.3f}"
         )
 
@@ -240,7 +234,7 @@ class TestSEMValidation:
         regs = comp[comp["category"] == "regressions"]
 
         for _, row in regs.iterrows():
-            assert row["diff"] < 0.3, (
+            assert row["diff"] < 0.2, (
                 f"Regression {row['param']}: ML={row['ml_est']:.3f}, "
                 f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
             )
@@ -250,7 +244,7 @@ class TestSEMValidation:
         loadings = comp[comp["category"] == "loadings"]
 
         for _, row in loadings.iterrows():
-            assert row["diff"] < 0.25, (
+            assert row["diff"] < 0.15, (
                 f"Loading {row['param']}: ML={row['ml_est']:.3f}, "
                 f"Bayes={row['bayes_mean']:.3f}, diff={row['diff']:.3f}"
             )

--- a/tests/test_prior_defaults.py
+++ b/tests/test_prior_defaults.py
@@ -1,0 +1,251 @@
+"""Tests for semla.prior_defaults — adaptive/weak prior resolution."""
+
+import numpy as np
+import pytest
+
+from semla.priors import Normal, HalfCauchy, InverseGamma, Gamma, Prior
+from semla.prior_defaults import (
+    resolve_priors,
+    _param_key,
+    _matrix_category,
+    MATRIX_KEYS,
+)
+from semla.specification import build_specification, ParamInfo
+from semla.syntax import parse_syntax
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def cfa_spec_and_data():
+    """Build a simple 2-factor CFA spec with synthetic data."""
+    syntax = """
+        f1 =~ x1 + x2 + x3
+        f2 =~ x4 + x5 + x6
+    """
+    tokens = parse_syntax(syntax)
+    observed = ["x1", "x2", "x3", "x4", "x5", "x6"]
+    spec = build_specification(tokens, observed)
+
+    rng = np.random.default_rng(42)
+    # data with different SDs per column
+    data = rng.normal(loc=0, scale=[1, 2, 3, 4, 5, 6], size=(200, 6))
+    return spec, data
+
+
+@pytest.fixture(scope="module")
+def regression_spec_and_data():
+    """Build a SEM spec with regressions."""
+    syntax = """
+        f1 =~ x1 + x2 + x3
+        f2 =~ x4 + x5 + x6
+        f2 ~ f1
+    """
+    tokens = parse_syntax(syntax)
+    observed = ["x1", "x2", "x3", "x4", "x5", "x6"]
+    spec = build_specification(tokens, observed, auto_cov_latent=False)
+
+    rng = np.random.default_rng(42)
+    data = rng.normal(loc=0, scale=2, size=(200, 6))
+    return spec, data
+
+
+# ── param_key / matrix_category ────────────────────────────────────────
+
+class TestParamKey:
+    def test_loading_key(self):
+        p = ParamInfo(lhs="f1", op="=~", rhs="x2", free=True, value=0.5)
+        assert _param_key(p) == "f1=~x2"
+
+    def test_variance_key(self):
+        p = ParamInfo(lhs="x1", op="~~", rhs="x1", free=True, value=0.5)
+        assert _param_key(p) == "x1~~x1"
+
+    def test_regression_key(self):
+        p = ParamInfo(lhs="f2", op="~", rhs="f1", free=True, value=0.0)
+        assert _param_key(p) == "f2~f1"
+
+
+class TestMatrixCategory:
+    def test_loading(self, cfa_spec_and_data):
+        spec, _ = cfa_spec_and_data
+        p = ParamInfo(lhs="f1", op="=~", rhs="x2", free=True, value=0.5)
+        assert _matrix_category(p, spec) == "loadings"
+
+    def test_residual_variance(self, cfa_spec_and_data):
+        spec, _ = cfa_spec_and_data
+        p = ParamInfo(lhs="x1", op="~~", rhs="x1", free=True, value=0.5)
+        assert _matrix_category(p, spec) == "residual_variances"
+
+    def test_factor_variance(self, cfa_spec_and_data):
+        spec, _ = cfa_spec_and_data
+        p = ParamInfo(lhs="f1", op="~~", rhs="f1", free=True, value=0.5)
+        assert _matrix_category(p, spec) == "factor_variances"
+
+    def test_covariance(self, cfa_spec_and_data):
+        spec, _ = cfa_spec_and_data
+        p = ParamInfo(lhs="f1", op="~~", rhs="f2", free=True, value=0.05)
+        assert _matrix_category(p, spec) == "covariances"
+
+    def test_regression(self, regression_spec_and_data):
+        spec, _ = regression_spec_and_data
+        p = ParamInfo(lhs="f2", op="~", rhs="f1", free=True, value=0.0)
+        assert _matrix_category(p, spec) == "regressions"
+
+
+# ── adaptive priors (default) ──────────────────────────────────────────
+
+class TestAdaptivePriors:
+    def test_returns_prior_for_every_free_param(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        n_free = sum(1 for p in spec.params if p.free)
+        assert len(result) == n_free
+
+    def test_all_values_are_prior_instances(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        for key, prior in result.items():
+            assert isinstance(prior, Prior), f"{key} is not a Prior"
+
+    def test_loading_scales_by_indicator_sd(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        # x2 has SD ~2, x5 has SD ~5
+        p_x2 = result.get("f1=~x2")
+        p_x5 = result.get("f2=~x5")
+        assert isinstance(p_x2, Normal)
+        assert isinstance(p_x5, Normal)
+        # x5 prior should be wider than x2
+        assert p_x5.sigma > p_x2.sigma
+
+    def test_residual_variance_is_inverse_gamma(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        p = result.get("x1~~x1")
+        assert isinstance(p, InverseGamma)
+
+    def test_factor_variance_is_inverse_gamma(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        p = result.get("f1~~f1")
+        assert isinstance(p, InverseGamma)
+
+    def test_covariance_prior_is_normal(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        p = result.get("f1~~f2")
+        assert isinstance(p, Normal)
+
+    def test_regression_prior(self, regression_spec_and_data):
+        spec, data = regression_spec_and_data
+        result = resolve_priors(spec, data)
+        p = result.get("f2~f1")
+        assert isinstance(p, Normal)
+
+
+# ── weak priors ─────────────────────────────────────────────────────────
+
+class TestWeakPriors:
+    def test_returns_prior_for_every_free_param(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data, priors="weak")
+        n_free = sum(1 for p in spec.params if p.free)
+        assert len(result) == n_free
+
+    def test_loading_is_wide_normal(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data, priors="weak")
+        p = result.get("f1=~x2")
+        assert isinstance(p, Normal)
+        assert p.sigma == 10.0
+
+    def test_variance_is_wide_inverse_gamma(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data, priors="weak")
+        p = result.get("x1~~x1")
+        assert isinstance(p, InverseGamma)
+        assert p.concentration == 0.01
+
+    def test_unknown_preset_raises(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        with pytest.raises(ValueError, match="Unknown prior preset"):
+            resolve_priors(spec, data, priors="strong")
+
+
+# ── matrix-level overrides ──────────────────────────────────────────────
+
+class TestMatrixOverrides:
+    def test_loading_override(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        custom = Normal(mu=0.0, sigma=0.5)
+        result = resolve_priors(spec, data, priors={"loadings": custom})
+        # all loadings should use the override
+        for key, prior in result.items():
+            if "=~" in key:
+                assert prior is custom
+
+    def test_variance_override_leaves_loadings_adaptive(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        custom_var = InverseGamma(concentration=5.0, rate=5.0)
+        result = resolve_priors(
+            spec, data,
+            priors={"residual_variances": custom_var},
+        )
+        # loadings should still be adaptive Normal
+        for key, prior in result.items():
+            if "=~" in key:
+                assert isinstance(prior, Normal)
+                assert prior.sigma != 10.0  # not weak default
+
+
+# ── per-parameter overrides ─────────────────────────────────────────────
+
+class TestPerParamOverrides:
+    def test_single_param_override(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        custom = Normal(mu=0.7, sigma=0.2)
+        result = resolve_priors(spec, data, priors={"f1=~x2": custom})
+        assert result["f1=~x2"] is custom
+        # other loadings should be adaptive
+        assert result.get("f1=~x3") is not custom
+
+    def test_param_overrides_matrix_level(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        matrix_prior = Normal(mu=0.0, sigma=0.5)
+        param_prior = Normal(mu=0.7, sigma=0.2)
+        result = resolve_priors(
+            spec, data,
+            priors={"loadings": matrix_prior, "f1=~x2": param_prior},
+        )
+        # f1=~x2 should use param override, not matrix override
+        assert result["f1=~x2"] is param_prior
+        # f1=~x3 should use matrix override
+        assert result["f1=~x3"] is matrix_prior
+
+    def test_unused_override_warns(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        with pytest.warns(UserWarning, match="unknown parameters ignored"):
+            resolve_priors(spec, data, priors={"f99=~z1": Normal(0, 1)})
+
+
+# ── validation ──────────────────────────────────────────────────────────
+
+class TestValidation:
+    def test_non_prior_value_raises(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        with pytest.raises(TypeError, match="must be a Prior instance"):
+            resolve_priors(spec, data, priors={"loadings": 5.0})
+
+    def test_fixed_params_excluded(self, cfa_spec_and_data):
+        spec, data = cfa_spec_and_data
+        result = resolve_priors(spec, data)
+        # first loading per factor is fixed to 1.0 — should not appear
+        assert "f1=~x1" not in result
+        assert "f2=~x4" not in result
+
+    def test_matrix_keys_constant(self):
+        assert MATRIX_KEYS == {
+            "loadings", "regressions", "residual_variances",
+            "factor_variances", "covariances", "intercepts",
+        }

--- a/tests/test_prior_defaults.py
+++ b/tests/test_prior_defaults.py
@@ -158,14 +158,14 @@ class TestWeakPriors:
         result = resolve_priors(spec, data, priors="weak")
         p = result.get("f1=~x2")
         assert isinstance(p, Normal)
-        assert p.sigma == 10.0
+        assert p.sigma == 5.0
 
-    def test_variance_is_wide_inverse_gamma(self, cfa_spec_and_data):
+    def test_variance_is_inverse_gamma(self, cfa_spec_and_data):
         spec, data = cfa_spec_and_data
         result = resolve_priors(spec, data, priors="weak")
         p = result.get("x1~~x1")
         assert isinstance(p, InverseGamma)
-        assert p.concentration == 0.01
+        assert p.concentration == 2.0
 
     def test_unknown_preset_raises(self, cfa_spec_and_data):
         spec, data = cfa_spec_and_data

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,0 +1,198 @@
+"""Tests for semla.priors — Prior distribution classes for Bayesian SEM."""
+
+import pytest
+
+numpyro = pytest.importorskip("numpyro")
+import jax
+import jax.numpy as jnp
+import numpyro.distributions as npdist
+
+from semla.priors import (
+    Prior,
+    Normal,
+    StudentT,
+    Cauchy,
+    Uniform,
+    Laplace,
+    HalfCauchy,
+    HalfNormal,
+    InverseGamma,
+    Exponential,
+    Gamma,
+    LogNormal,
+    LKJ,
+    Beta,
+)
+
+
+class TestPriorBase:
+    """Tests for the Prior base class."""
+
+    def test_base_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            Prior().to_numpyro()
+
+
+class TestUnboundedPriors:
+    """Tests for priors with support on the real line."""
+
+    def test_normal_defaults(self):
+        p = Normal()
+        assert p.mu == 0.0
+        assert p.sigma == 1.0
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Normal)
+
+    def test_normal_custom(self):
+        p = Normal(mu=5.0, sigma=2.0)
+        d = p.to_numpyro()
+        sample = d.sample(jax.random.PRNGKey(0))
+        assert sample.shape == ()
+
+    def test_student_t_defaults(self):
+        p = StudentT()
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.StudentT)
+
+    def test_student_t_custom(self):
+        p = StudentT(df=5.0, loc=1.0, scale=2.0)
+        d = p.to_numpyro()
+        assert d.sample(jax.random.PRNGKey(1)).shape == ()
+
+    def test_cauchy(self):
+        p = Cauchy(loc=0.0, scale=2.5)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Cauchy)
+
+    def test_uniform(self):
+        p = Uniform(low=-1.0, high=1.0)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Uniform)
+
+    def test_laplace(self):
+        p = Laplace(loc=0.0, scale=1.0)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Laplace)
+
+
+class TestPositivePriors:
+    """Tests for priors with support on positive reals."""
+
+    def test_half_cauchy(self):
+        p = HalfCauchy(scale=2.5)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.HalfCauchy)
+
+    def test_half_normal(self):
+        p = HalfNormal(scale=1.0)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.HalfNormal)
+
+    def test_inverse_gamma(self):
+        p = InverseGamma(concentration=2.0, rate=1.0)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.InverseGamma)
+
+    def test_exponential(self):
+        p = Exponential(rate=0.5)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Exponential)
+
+    def test_gamma(self):
+        p = Gamma(concentration=2.0, rate=1.0)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Gamma)
+
+    def test_log_normal(self):
+        p = LogNormal(loc=0.0, scale=0.5)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.LogNormal)
+
+
+class TestCorrelationPriors:
+    """Tests for correlation-related priors."""
+
+    def test_lkj_defaults(self):
+        p = LKJ()
+        assert p.dim == 2
+        assert p.concentration == 1.0
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.LKJCholesky)
+
+    def test_lkj_custom(self):
+        p = LKJ(dim=4, concentration=2.0)
+        d = p.to_numpyro()
+        sample = d.sample(jax.random.PRNGKey(42))
+        assert sample.shape == (4, 4)
+
+    def test_beta(self):
+        p = Beta(concentration1=2.0, concentration0=5.0)
+        d = p.to_numpyro()
+        assert isinstance(d, npdist.Beta)
+
+
+class TestDataclassBehavior:
+    """Tests that priors behave correctly as dataclasses."""
+
+    def test_equality(self):
+        assert Normal(0, 1) == Normal(0, 1)
+        assert Normal(0, 1) != Normal(0, 2)
+
+    def test_repr(self):
+        r = repr(Normal(mu=0.0, sigma=1.0))
+        assert "Normal" in r
+        assert "mu=0.0" in r
+
+    def test_all_priors_are_dataclasses(self):
+        import dataclasses
+
+        for cls in [
+            Normal, StudentT, Cauchy, Uniform, Laplace,
+            HalfCauchy, HalfNormal, InverseGamma, Exponential, Gamma, LogNormal,
+            LKJ, Beta,
+        ]:
+            assert dataclasses.is_dataclass(cls), f"{cls.__name__} is not a dataclass"
+
+    def test_all_priors_subclass_prior(self):
+        for cls in [
+            Normal, StudentT, Cauchy, Uniform, Laplace,
+            HalfCauchy, HalfNormal, InverseGamma, Exponential, Gamma, LogNormal,
+            LKJ, Beta,
+        ]:
+            assert issubclass(cls, Prior), f"{cls.__name__} does not inherit Prior"
+
+
+class TestLogProb:
+    """Verify that the numpyro distributions produce valid log-probabilities."""
+
+    @pytest.mark.parametrize("prior,value", [
+        (Normal(0, 1), 0.5),
+        (StudentT(3, 0, 1), 0.5),
+        (Cauchy(0, 1), 0.5),
+        (Uniform(0, 1), 0.5),
+        (Laplace(0, 1), 0.5),
+        (HalfCauchy(1), 0.5),
+        (HalfNormal(1), 0.5),
+        (InverseGamma(1, 1), 0.5),
+        (Exponential(1), 0.5),
+        (Gamma(1, 1), 0.5),
+        (LogNormal(0, 1), 0.5),
+        (Beta(2, 2), 0.5),
+    ])
+    def test_finite_log_prob(self, prior, value):
+        d = prior.to_numpyro()
+        lp = d.log_prob(jnp.array(value))
+        assert jnp.isfinite(lp)
+
+
+class TestImportPath:
+    """Verify the public import path works."""
+
+    def test_import_from_semla_priors(self):
+        from semla.priors import Normal, HalfCauchy, LKJ
+        assert Normal is not None
+
+    def test_import_priors_module(self):
+        import semla
+        assert hasattr(semla, "priors")
+        assert hasattr(semla.priors, "Normal")


### PR DESCRIPTION
## Summary
- Full Bayesian SEM estimation backend using NumPyro/JAX NUTS sampler
- Prior distribution classes (`semla.priors`): Normal, StudentT, Cauchy, HalfCauchy, InverseGamma, LKJ, etc.
- Data-adaptive priors (brms-style, scaled by observed SDs) and weak informative preset
- Adaptive convergence: auto-retry with extended draws or higher adapt_delta when R-hat > 1.01
- `BayesianResults` with `.draws()`, `.estimates()`, `.summary()`, `.waic()`, `.loo()`, `.diagnostics()`
- Parallel chain execution on CPU (`cores` kwarg or `semla.set_host_devices()`)
- Positive loading constraints to prevent sign-flipping in structural models

**API:**
```python
fit = cfa(model, data, estimator="bayes")
fit = cfa(model, data, estimator="bayes", priors="weak", chains=4, draws=2000, cores=4)
fit = sem(model, data, estimator="bayes", priors={"loadings": Normal(0, 1)})
```

## Validation
- CFA on Holzinger-Swineford 1939: all parameters within 0.033 of ML, R-hat = 1.000
- SEM with latent regressions: converges and matches ML after positive loading fix
- 117 new tests across 6 test files, all passing

## Test plan
- [x] Prior classes: all 13 distributions convert to NumPyro and produce valid log-probs
- [x] Prior defaults: adaptive scaling, weak preset, matrix/param overrides, tier priority
- [x] Model builder: traces without error, handles mean structure and equality constraints
- [x] Adaptive convergence: R-hat checking, divergence monitoring, auto-retry
- [x] BayesianResults: draws, estimates, diagnostics, WAIC, LOO, summary output
- [x] Integration: `cfa()`/`sem()` with `estimator="bayes"`, custom priors, weak priors
- [x] Validation: Bayesian vs ML on Holzinger-Swineford (CFA + SEM)

Closes #18, #27, #28, #29, #30, #31, #32, #33, #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)